### PR TITLE
Add pagination to qry_scopes

### DIFF
--- a/lusidtools/lpt/qry_scopes.py
+++ b/lusidtools/lpt/qry_scopes.py
@@ -61,8 +61,6 @@ def process_args(api, args):
             args.limit,
             sort=['Scope','Portfolio'] if args.portfolios else 'Scopes')
 
-    return api.call.list_portfolios().bind(success)
-
 
 # Standalone tool
 def main(parse=parse, display_df=lpt.display_df):

--- a/lusidtools/lpt/qry_scopes.py
+++ b/lusidtools/lpt/qry_scopes.py
@@ -3,6 +3,11 @@ import dateutil
 from lusidtools.lpt import lpt
 from lusidtools.lpt import lse
 from lusidtools.lpt import stdargs
+from .either import Either
+import re
+import urllib.parse
+
+rexp = re.compile(r".*page=([^=']{10,}).*")
 
 
 def parse(extend=None, args=None):
@@ -15,14 +20,18 @@ def parse(extend=None, args=None):
 
 
 def process_args(api, args):
-    def success(result):
+    results = []
+
+    def fetch_page(page_token):
+        return api.call.list_portfolios(page=page_token)
+
+    def got_page(result):
         if args.portfolios:
             df = lpt.to_df(
                 result,
                 ["id.scope", "id.code", "is_derived", "type", "parent_portfolio_id"],
             )
             df.columns = ["Scope", "Portfolio", "Derived", "Type", "Parent"]
-            return lpt.trim_df(df, args.limit, sort=["Scope", "Portfolio"])
         else:
             df = (
                 pd.DataFrame({"Scopes": [v.id.scope for v in result.content.values]})
@@ -30,7 +39,27 @@ def process_args(api, args):
                 .size()
                 .reset_index()
             )
-            return lpt.trim_df(df, args.limit, sort="Scopes")
+        results.append(df)
+
+        links = [l for l in result.content.links if l.relation=='NextPage']
+
+        if len(links) > 0:
+           match = rexp.match(links[0].href)
+           if match:
+              return urllib.parse.unquote(match.group(1))
+        return None
+
+    page = Either(None)
+    while True:
+          page = fetch_page(page.right).bind(got_page)
+          if page.is_left():
+             return page
+          if page.right == None:
+             break
+
+    return lpt.trim_df(pd.concat(results,ignore_index=True,sort=False),
+            args.limit,
+            sort=['Scope','Portfolio'] if args.portfolios else 'Scopes')
 
     return api.call.list_portfolios().bind(success)
 


### PR DESCRIPTION
The list_portfolios endpoint now returns 5000 portfolios max by default.
If there are more than 5000 portfolios, this enhancement will page-in
the remainder.

# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
