### PR TITLE
DEV-7530: Add master_doc parameter to Docs conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,3 +63,5 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+master_doc = "index"

--- a/lusidtools/apps/upsert_instruments.py
+++ b/lusidtools/apps/upsert_instruments.py
@@ -66,7 +66,7 @@ def load_instruments(args):
     succ, errors, failed = cocoon_printer.format_instruments_response(
         instruments_response
     )
-    logging.info(f"number of successful upserts: {len(succ)}")
+    logging.info(f"number of successful upserts: {len(succ)}")     
     logging.info(f"number of failed upserts    : {len(failed)}")
     logging.info(f"number of errors            : {len(errors)}")
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

The Readthedocs build is getting sphinx error (still builds fine locally). This change explicitly states the name of the master document for the documentation to be called `index.rst` and not `contents.rst`.

A link to the suggested fix is provided here:
https://github.com/readthedocs/readthedocs.org/issues/2569


error:
```
Sphinx error:
master file /home/docs/checkouts/readthedocs.org/user_builds/lusidtools/checkouts/latest/docs/source/contents.rst not found
```
