### PR TITLE
DEV-7602: Fixed cocoon printer returning nan

### DIFF
--- a/lusidtools/cocoon/cocoon_printer.py
+++ b/lusidtools/cocoon/cocoon_printer.py
@@ -154,9 +154,9 @@ def format_instruments_response(
     items_success, items_failed = get_non_href_response(response, file_type)
 
     return (
-        pd.DataFrame(items_success, columns=["successful items"]),
+        items_success,
         get_errors_from_response(response[file_type]["errors"]),
-        pd.DataFrame(items_failed, columns=["failed_items"]),
+        items_failed,
     )
 
 
@@ -298,7 +298,7 @@ def format_quotes_response(
     )
 
     return (
-        pd.DataFrame(items_success),
+        items_success,
         get_errors_from_response(response[file_type]["errors"]),
-        pd.DataFrame(items_failed, columns=["failed_items"]),
+        items_failed,
     )

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -381,62 +381,103 @@ class CocoonPrinterTests(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("standard_response", responses, 2),
-            ("empty_response", empty_response_with_full_shape, 0),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0),
+            ("standard_response", responses,  2,
+             {
+                 "succ": ["ClientInternal: imd_00001234", "ClientInternal: imd_00001234"],
+                 "failed": ["ClientInternal: imd_00001234", "ClientInternal: imd_00001234"],
+                 "err": ["not found", "not found"]
+             }),
+            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}),
         ]
     )
-    def test_format_instruments_response_success(self, _, response, num_items):
+    def test_format_instruments_response_success(self, _, response, num_items, ground_truth):
         succ, err, failed = format_instruments_response(response)
         self.assertEqual(num_items, len(failed))
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
 
+        [self.assertEqual(ground_truth["succ"][index], row[succ.columns[0]]) for index, row in succ.iterrows()]
+        [self.assertEqual(ground_truth["failed"][index], row[failed.columns[0]]) for index, row in failed.iterrows()]
+        [self.assertEqual(ground_truth["err"][index], row[err.columns[0]]) for index, row in err.iterrows()]
     @parameterized.expand(
         [
-            ("standard_response", responses, 2),
-            ("empty_response", empty_response_with_full_shape, 0),
+            ("standard_response", responses, 2,
+             {
+                 "succ": ["ID00001", "ID00001"],
+                 "err": ["not found", "not found"]
+             }
+             ),
+            ("empty_response", empty_response_with_full_shape, 0, {}),
         ]
     )
-    def test_format_portfolios_response_success(self, _, response, num_items):
+    def test_format_portfolios_response_success(self, _, response, num_items, ground_truth):
         succ, err = format_portfolios_response(response)
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
 
+        [self.assertEqual(ground_truth["succ"][index], row[succ.columns[0]]) for index, row in succ.iterrows()]
+        [self.assertEqual(ground_truth["err"][index], row[err.columns[0]]) for index, row in err.iterrows()]
+
     @parameterized.expand(
         [
-            ("standard_response", responses, 2),
-            ("empty_response", empty_response_with_full_shape, 0),
+            ("standard_response", responses, 2,
+             {
+                 "succ": ["code", "code"],
+                 "err": ["not found", "not found"]
+             }
+             ),
+            ("empty_response", empty_response_with_full_shape, 0, {}),
         ]
     )
-    def test_format_transactions_response_success(self, _, response, num_items):
+    def test_format_transactions_response_success(self, _, response, num_items, ground_truth):
         succ, err = format_transactions_response(response)
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
 
+        [self.assertEqual(ground_truth["succ"][index], row[succ.columns[0]]) for index, row in succ.iterrows()]
+        [self.assertEqual(ground_truth["err"][index], row[err.columns[0]]) for index, row in err.iterrows()]
     @parameterized.expand(
         [
-            ("standard_response", responses, 2),
-            ("empty_response", empty_response_with_full_shape, 0),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0),
+            ("standard_response", responses, 2,
+             {
+                 "succ": ["BBG001MM1KV4", "BBG001MM1KV4"],
+                 "failed": ["BBG001MM1KV4", "BBG001MM1KV4"],
+                 "err": ["not found", "not found"]
+             }
+             ),
+            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}),
         ]
     )
-    def test_format_quotes_response_success(self, _, response, num_items):
+    def test_format_quotes_response_success(self, _, response, num_items, ground_truth):
         succ, err, failed = format_quotes_response(response)
         self.assertEqual(num_items, len(failed))
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
 
+        [self.assertEqual(ground_truth["succ"][index], row['quote_id.quote_series_id.instrument_id']) for index, row in succ.iterrows()]
+        [self.assertEqual(ground_truth["failed"][index], row['quote_id.quote_series_id.instrument_id']) for index, row in failed.iterrows()]
+        [self.assertEqual(ground_truth["err"][index], row[err.columns[0]]) for index, row in err.iterrows()]
+
     @parameterized.expand(
         [
-            ("standard_response", responses, 2),
-            ("empty_response", empty_response_with_full_shape, 0),
+            ("standard_response", responses, 2,
+             {
+                 "succ": ["code", "code"],
+                 "err": ["not found", "not found"]
+             }
+             ),
+            ("empty_response", empty_response_with_full_shape, 0, {}),
         ]
     )
-    def test_format_holdings_response_success(self, _, response, num_items):
+    def test_format_holdings_response_success(self, _, response, num_items, ground_truth):
         succ, err = format_holdings_response(response)
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
+
+        [self.assertEqual(ground_truth["succ"][index], row[succ.columns[0]]) for index, row in succ.iterrows()]
+        [self.assertEqual(ground_truth["err"][index], row[err.columns[0]]) for index, row in err.iterrows()]
 
     # Test failure cases
 


### PR DESCRIPTION
Checks each row in output dataframe contains some correct data against provided ground truth value

DEV-7602: Fixed cocoon printer returning nan

For quotes and instruments

# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

Fixed printer bug where format_instruments_response and format_quotes_response returned NaN instead of the instrument IDs.


