### PR TITLE
DEV-7768: Bugfix - dfq filter options

### DIFF
--- a/lusidtools/lpt/dfq.py
+++ b/lusidtools/lpt/dfq.py
@@ -92,6 +92,7 @@ def dfq(args, given_df=None):
         args.first
         if args.first > 0
         and args.last == 0
+        and given_df is None
         and args.groupby is None
         and args.where is None
         and args.order is None
@@ -104,7 +105,7 @@ def dfq(args, given_df=None):
 
         args.input = glob.glob(args.input[0])
 
-    if args.columns:
+    if args.columns and given_df is None:
         args.input = args.input[0:1]
         nrows = 2
 

--- a/lusidtools/lpt/lse.py
+++ b/lusidtools/lpt/lse.py
@@ -4,8 +4,6 @@ import inspect
 import json
 import os
 
-import msrest
-
 from . import lpt
 from .either import Either
 from .record import Rec
@@ -114,16 +112,6 @@ class Caller:
                     err.status,
                     {},
                 ]
-            except msrest.exceptions.ClientRequestError as cerr:
-                return Either.Left(
-                    "ERROR: exception in call to {}\n{}".format(name, cerr)
-                )
-            except msrest.exceptions.HttpOperationError as herr:
-                return Either.Left(
-                    "ERROR: exception in call to {}\n{}".format(
-                        name, herr.response.text
-                    )
-                )
 
             endTime = datetime.datetime.now()
 


### PR DESCRIPTION
If we use the dfq filter and use any option that
refers to the input, an exception is thrown.

e.g.
to only show the first 5 records,
     xxxx --dfq -f 5

This fix will prevent that from happening.

Also, remove references to msrest in lse.py
These are causing warnings in pytest

# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
