### PR TITLE
DEV-7819: Deal with Null property values as 'nan'

### DIFF
--- a/lusidtools/lpt/lpt.py
+++ b/lusidtools/lpt/lpt.py
@@ -136,7 +136,7 @@ def from_df(
                     key=property_key,
                     value=complex_types["PropertyValue"](label_value=value),
                 )
-            elif value != None:
+            elif pd.isna(value) == False:
                 return ptype(
                     key=property_key,
                     value=complex_types["PropertyValue"](


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

Metric property values were being created as the string 'nan' 
Check for empty values in a dataframe using pd.isna() instead of comparison with None
