### PR TITLE
DEV-7989 Fixed test after change from DEV-7620 Instead of the scope a…

### DIFF
--- a/tests/integration/extract/test_group_holdings.py
+++ b/tests/integration/extract/test_group_holdings.py
@@ -118,10 +118,10 @@ class CocoonTestsExtractGroupHoldings(unittest.TestCase):
     ):
 
         # Check that there are the right number of results and they have the correct keys
-        self.assertEqual(set(group_holdings.keys()), set(expected_values.keys()))
+        self.assertSetEqual(set(group_holdings.keys()), set(expected_values.keys()))
 
         if lusid_results_keyed is not None:
-            self.assertEqual(
+            self.assertSetEqual(
                 set(group_holdings.keys()), set(lusid_results_keyed.keys())
             )
 
@@ -377,9 +377,10 @@ class CocoonTestsExtractGroupHoldings(unittest.TestCase):
         # Key the LUSID result against portfolio and then instrument name
         lusid_results_keyed = {}
         for holding in lusid_results.values:
-            portfolio = holding.properties[
-                "Holding/default/SourcePortfolioId"
-            ].value.label_value.replace("/", " : ")
+            portfolio_scope = holding.properties["Holding/default/SourcePortfolioScope"].value.label_value
+            portfolio_code = holding.properties["Holding/default/SourcePortfolioId"].value.label_value
+            portfolio = f"{portfolio_scope} : {portfolio_code}"
+
             instrument_name = holding.properties[
                 "Instrument/default/Name"
             ].value.label_value


### PR DESCRIPTION
…nd code of a source portfolio being returned as a / seperated string in Holding/default/SourcePortfolioId, they are now populated in separate properties.  Scope: Holding/default/SourcePortfolioScope Code:  Holding/default/SourcePortfolioId  Need to update the test which checks that the LUSID Tools function get_holdings_for_group gets the same result as you would from LUSID via the Get Holdings for Group API to reflect this change.

# Pull Request Checklist

- [x ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x ] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
