### PR TITLE
DEV-7676 Adding validation checks in default_FX_forward_model

### DIFF
--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -1418,6 +1418,9 @@ def default_fx_forward_model(
         f"combining transactions of type {fx_code} into a single line using {default_fx_forward_model.__name__}"
         f" utility function"
     )
+    if fx_code not in df["type"].values:
+        raise ValueError(f"Input transactions have no fx transaction types {fx_code}")
+
     t_type = mapping["transactions"]["required"]["type"]
 
     fwds_df = pd.DataFrame(df[df[t_type] == fx_code])

--- a/tests/unit/cocoon/test_utilities.py
+++ b/tests/unit/cocoon/test_utilities.py
@@ -1952,6 +1952,65 @@ class CocoonUtilitiesTests(unittest.TestCase):
     @parameterized.expand(
         [
             (
+                    "No fx forward transactions present.",
+                    pd.DataFrame(
+                        data=[
+                            [1000, 1, 1, -500, "GBP", "NonFxType1", "b1", "2020/01/01"],
+                            [1001, 1, 1, 500, "GBP", "NonFxType2", "sl", "2020/01/01"],
+                            [1002, 1, 1, -500, "USD", "NonFxType3", "~", "2020/01/01"],
+                        ],
+                        columns=[
+                            "TX_ID",
+                            "Price",
+                            "price (local)",
+                            "quantity",
+                            "currency",
+                            "type",
+                            "leg",
+                            "date",
+                        ],
+                    ),
+                    {
+                        "transactions": {
+                            "required": {
+                                "code": "$fund_id",
+                                "settlement_date": "date",
+                                "total_consideration.amount": "quantity",
+                                "total_consideration.currency": "currency",
+                                "transaction_currency": "currency",
+                                "transaction_date": "date",
+                                "transaction_id": "TX_ID",
+                                "transaction_price.price": "Price",
+                                "transaction_price.type": "$Price",
+                                "type": "type",
+                                "units": "quantity",
+                            }
+                        }
+                    },
+                    ValueError
+            )
+        ]
+    )
+    def test_default_fx_forward_model_on_missing_fx_transaction_type(
+            self, _, df_with_no_fx_transactions, mapping, expected_exception
+    ):
+        """
+                This tests that an exception is raised if a set of transactions is passed in  and do not contain
+                any transactions with an fx type as defined by the fx_code parameter.
+
+                :param pd.dataFrame df_with_no_fx_transactions : input set of transactions with no fx transactions
+                :param dict mapping: fx transactions mapping
+                :param expected_exception: expected exception on missing fx transaction
+
+                :return: None
+                """
+
+        with self.assertRaises(expected_exception):
+            default_fx_forward_model(df_with_no_fx_transactions, "FW", None, None, mapping)
+
+    @parameterized.expand(
+        [
+            (
                 "Replace one single matching value standard syntax",
                 {
                     "a1": {

--- a/tests/unit/cocoon/test_utilities.py
+++ b/tests/unit/cocoon/test_utilities.py
@@ -1938,7 +1938,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
             )
         ]
     )
-    def test_default_fx_forward_model(
+    def test_default_fx_forward_model_success(
         self, _, df, df_gt, mapping, mapping_gt, fun1, fun2
     ):
 
@@ -1991,7 +1991,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
             )
         ]
     )
-    def test_default_fx_forward_model_on_missing_fx_transaction_type(
+    def test_default_fx_forward_model_failure(
             self, _, df_with_no_fx_transactions, mapping, expected_exception
     ):
         """


### PR DESCRIPTION
- Raise an exception if no transactions exists as per the specified
fx forward transaction type code for default_FX_forward_model method

- Add test case to ensure exception raised as per requirement above.

# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
