### PR TITLE
DEV-8525 Remove deprecated numpy.datetime64 keyword arguments format …

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -175,7 +175,9 @@ class BatchLoader:
         return api_factory.build(
             lusid.api.TransactionPortfoliosApi
         ).upsert_transactions(
-            scope=kwargs["scope"], code=kwargs["code"], transaction_request=transaction_batch
+            scope=kwargs["scope"],
+            code=kwargs["code"],
+            transaction_request=transaction_batch,
         )
 
     @staticmethod
@@ -289,7 +291,8 @@ class BatchLoader:
                 return api_factory.build(
                     lusid.api.TransactionPortfoliosApi
                 ).create_portfolio(
-                    scope=kwargs["scope"], create_transaction_portfolio_request=portfolio_batch[0]
+                    scope=kwargs["scope"],
+                    create_transaction_portfolio_request=portfolio_batch[0],
                 )
             else:
                 return e
@@ -328,7 +331,9 @@ class BatchLoader:
             # find the matching instruments
             mastered_instruments = api_factory.build(
                 lusid.api.SearchApi
-            ).instruments_search(instrument_search_property=[search_request], mastered_only=True)
+            ).instruments_search(
+                instrument_search_property=[search_request], mastered_only=True
+            )
 
             # flat map the results to a list of luids
             luids = [
@@ -464,7 +469,10 @@ class BatchLoader:
             if e.status == 404:
                 return api_factory.build(
                     lusid.api.PortfolioGroupsApi
-                ).create_portfolio_group(scope=kwargs["scope"], create_portfolio_group_request=updated_request)
+                ).create_portfolio_group(
+                    scope=kwargs["scope"],
+                    create_portfolio_group_request=updated_request,
+                )
             else:
                 return e
 

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -225,7 +225,9 @@ def create_property_definitions_from_file(
         # Call LUSID to create the new property
         property_response = api_factory.build(
             lusid.PropertyDefinitionsApi
-        ).create_property_definition(create_property_definition_request=property_request)
+        ).create_property_definition(
+            create_property_definition_request=property_request
+        )
 
         logging.info(
             f"Created - {property_response.key} - with datatype {property_response.data_type_id.code}"

--- a/lusidtools/lpt/create_properties.py
+++ b/lusidtools/lpt/create_properties.py
@@ -45,7 +45,9 @@ def process_args(api, args):
     ) as iter:
         for prop in iter:
             iter.set_description(prop.display_name)
-            result = api.call.create_property_definition(create_property_definition_request=prop)
+            result = api.call.create_property_definition(
+                create_property_definition_request=prop
+            )
             if result.left is not None:
                 return result
 

--- a/lusidtools/lpt/upload_portfolio.py
+++ b/lusidtools/lpt/upload_portfolio.py
@@ -75,7 +75,9 @@ def process_args(api, args):
                 return api.call.upsert_transactions(
                     args.scope,
                     portfolio,
-                    transaction_request=api.from_df(txns, api.models.TransactionRequest),
+                    transaction_request=api.from_df(
+                        txns, api.models.TransactionRequest
+                    ),
                 )
 
             if args.portfolio.lower().startswith("col:"):

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -665,7 +665,8 @@ class CocoonTestsInstruments(unittest.TestCase):
 
         self.assertTrue(
             expr=all(
-                sorted(combined_successes[key].properties, key=lambda p: p.key) == sorted(value.properties, key=lambda p: p.key)
+                sorted(combined_successes[key].properties, key=lambda p: p.key)
+                == sorted(value.properties, key=lambda p: p.key)
                 for key, value in expected_outcome["instruments"].values.items()
             )
         )
@@ -821,7 +822,8 @@ class CocoonTestsInstruments(unittest.TestCase):
 
         self.assertTrue(
             expr=all(
-                sorted(combined_successes[key].properties, key=lambda p: p.key) == sorted(value.properties, key=lambda p: p.key)
+                sorted(combined_successes[key].properties, key=lambda p: p.key)
+                == sorted(value.properties, key=lambda p: p.key)
                 for key, value in expected_outcome["instruments"].values.items()
             )
         )
@@ -945,7 +947,6 @@ class CocoonTestsInstruments(unittest.TestCase):
                     for response in responses["instruments"]["success"]
                 ]
             ),
-
         )
 
         self.assertEqual(
@@ -966,7 +967,8 @@ class CocoonTestsInstruments(unittest.TestCase):
 
         self.assertTrue(
             expr=all(
-                sorted(combined_successes[key].properties, key=lambda p: p.key) == sorted(value.properties, key=lambda p: p.key)
+                sorted(combined_successes[key].properties, key=lambda p: p.key)
+                == sorted(value.properties, key=lambda p: p.key)
                 for key, value in expected_outcome["instruments"].values.items()
             )
         )

--- a/tests/unit/cocoon/test_dateorcutlabel.py
+++ b/tests/unit/cocoon/test_dateorcutlabel.py
@@ -84,8 +84,8 @@ class CocoonDateOrCutLabelTests(unittest.TestCase):
                 "2019-09-01T09:31:22.664000+00:00",
             ],
             [
-                "numpy datetime64 UTC false",
-                np.datetime64("2019-07-02", format="%Y%m%d", utc=False),
+                "numpy datetime64",
+                np.datetime64("2019-07-02"),
                 "2019-07-02T00:00:00.000000Z",
             ],
         ]

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -42,7 +42,9 @@ class CocoonPropertiesTests(unittest.TestCase):
                 """
                 return lusid.models.PropertyDefinition(
                     key="{}/{}/{}".format(
-                        create_property_definition_request.domain, create_property_definition_request.scope, create_property_definition_request.code
+                        create_property_definition_request.domain,
+                        create_property_definition_request.scope,
+                        create_property_definition_request.code,
                     ),
                     data_type_id=lusid.models.ResourceId(
                         scope=create_property_definition_request.data_type_id.scope,


### PR DESCRIPTION
…and utc. numpy.datetime64 is always assumed to be datetime naive. Keep in mind that this is also an expiremental API from numpy

# Pull Request Checklist

- [x ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x ] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
