### PR TITLE
Feature/se 100.format reference portfolios response

### DIFF
--- a/lusidtools/cocoon/cocoon_printer.py
+++ b/lusidtools/cocoon/cocoon_printer.py
@@ -302,3 +302,32 @@ def format_quotes_response(
         get_errors_from_response(response[file_type]["errors"]),
         items_failed,
     )
+
+def format_reference_portfolios_response(response: dict) -> (pd.DataFrame, pd.DataFrame):
+    """
+    This function unpacks a response from reference portfolio requests and returns successful and errored statuses for request constituents.
+
+    Parameters
+    ----------
+    response : dict
+        response from Lusid-python-tools
+
+    Returns
+    -------
+    success : pd.DataFrame
+        successful calls from request
+    error : pd.DataFrame
+        Error responses from rquest that fail (APIExceptions: 400 errors)
+    """
+
+    file_type = "reference_portfolios"
+    check_dict_for_required_keys(
+        response[file_type], f"Response from {file_type} request", ["errors","success"]   
+    )
+
+    # get success
+    items_success = [batch.id.code for batch in response[file_type]["success"]]
+
+    errors = get_errors_from_response(response[file_type]["errors"])
+
+    return (pd.DataFrame(items_success, columns=["successful items"]), errors)

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -179,6 +179,13 @@ responses_no_success_field = {
     "reference_portfolios": {"errors": [api_exception for _ in range(2)],},
 }
 
+def assert_responses(self, num_items, expected_value, succ=None, err=None, failed=None):
+        for response in [succ, err, failed]:
+            if response is not None:
+                self.assertEqual(num_items, len(response))
+                for index, row in response.iterrows():
+                    self.assertEqual(expected_value[f"{response}"][index], row[response.columns[0]])
+
 
 class CocoonPrinterTests(unittest.TestCase):
     @classmethod
@@ -242,22 +249,23 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_instruments_response(response)
-        self.assertEqual(num_items, len(failed))
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err, failed=failed)
+        # self.assertEqual(num_items, len(failed))
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["failed"][index], row[failed.columns[0]])
-            for index, row in failed.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["failed"][index], row[failed.columns[0]])
+        #     for index, row in failed.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
     @parameterized.expand(
         [
@@ -274,17 +282,18 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_portfolios_response(response)
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err)
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
     @parameterized.expand(
         [
@@ -301,17 +310,18 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_transactions_response(response)
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err)
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
     @parameterized.expand(
         [
@@ -333,28 +343,29 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_quotes_response(response)
-        self.assertEqual(num_items, len(failed))
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err, failed=failed)
+        # self.assertEqual(num_items, len(failed))
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(
-                expected_value["succ"][index],
-                row["quote_id.quote_series_id.instrument_id"],
-            )
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(
-                expected_value["failed"][index],
-                row["quote_id.quote_series_id.instrument_id"],
-            )
-            for index, row in failed.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(
+        #         expected_value["succ"][index],
+        #         row["quote_id.quote_series_id.instrument_id"],
+        #     )
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(
+        #         expected_value["failed"][index],
+        #         row["quote_id.quote_series_id.instrument_id"],
+        #     )
+        #     for index, row in failed.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
     @parameterized.expand(
         [
@@ -371,17 +382,18 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_holdings_response(response)
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err)
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
     @parameterized.expand(
         [
@@ -398,17 +410,18 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_reference_portfolios_response(response)
-        self.assertEqual(num_items, len(succ))
-        self.assertEqual(num_items, len(err))
+        assert_responses(self, num_items, expected_value, succ=succ, err=err)
+        # self.assertEqual(num_items, len(succ))
+        # self.assertEqual(num_items, len(err))
 
-        [
-            self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-            for index, row in succ.iterrows()
-        ]
-        [
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-            for index, row in err.iterrows()
-        ]
+        # [
+        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+        #     for index, row in succ.iterrows()
+        # ]
+        # [
+        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        #     for index, row in err.iterrows()
+        # ]
 
 
     # Test failure cases

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -320,9 +320,16 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_quotes_response(response)
-        self.assert_responses(
-            num_items, expected_value, succ=succ, err=err, failed=failed
-        )
+        self.assertEqual(num_items, len(succ))
+        self.assertEqual(num_items, len(err))
+        self.assertEqual(num_items, len(failed))
+
+        for index, row in succ.iterrows():
+            self.assertEqual(expected_value["succ"][index], row["quote_id.quote_series_id.instrument_id"])
+        for index, row in err.iterrows():
+            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        for index, row in failed.iterrows():
+            self.assertEqual(expected_value["failed"][index], row["quote_id.quote_series_id.instrument_id"])
 
     @parameterized.expand(
         [

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -179,14 +179,17 @@ responses_no_success_field = {
     "reference_portfolios": {"errors": [api_exception for _ in range(2)],},
 }
 
+
 class CocoonPrinterTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
 
         cls.logger = logger.LusidLogger("debug")
-        
-    def assert_responses(self, num_items, expected_value, succ=None, err=None, failed=None):
+
+    def assert_responses(
+        self, num_items, expected_value, succ=None, err=None, failed=None
+    ):
         if succ is not None:
             self.assertEqual(num_items, len(succ))
             for index, row in succ.iterrows():
@@ -200,7 +203,9 @@ class CocoonPrinterTests(unittest.TestCase):
         if failed is not None:
             self.assertEqual(num_items, len(failed))
             for index, row in failed.iterrows():
-                self.assertEqual(expected_value["failed"][index], row[failed.columns[0]])
+                self.assertEqual(
+                    expected_value["failed"][index], row[failed.columns[0]]
+                )
 
     @parameterized.expand(
         [
@@ -257,7 +262,9 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_instruments_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, failed=failed)
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, failed=failed
+        )
 
     @parameterized.expand(
         [
@@ -313,7 +320,9 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_quotes_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, failed=failed)
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, failed=failed
+        )
 
     @parameterized.expand(
         [

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -325,11 +325,17 @@ class CocoonPrinterTests(unittest.TestCase):
         self.assertEqual(num_items, len(failed))
 
         for index, row in succ.iterrows():
-            self.assertEqual(expected_value["succ"][index], row["quote_id.quote_series_id.instrument_id"])
+            self.assertEqual(
+                expected_value["succ"][index],
+                row["quote_id.quote_series_id.instrument_id"],
+            )
         for index, row in err.iterrows():
             self.assertEqual(expected_value["err"][index], row[err.columns[0]])
         for index, row in failed.iterrows():
-            self.assertEqual(expected_value["failed"][index], row["quote_id.quote_series_id.instrument_id"])
+            self.assertEqual(
+                expected_value["failed"][index],
+                row["quote_id.quote_series_id.instrument_id"],
+            )
 
     @parameterized.expand(
         [

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -179,20 +179,28 @@ responses_no_success_field = {
     "reference_portfolios": {"errors": [api_exception for _ in range(2)],},
 }
 
-def assert_responses(self, num_items, expected_value, succ=None, err=None, failed=None):
-        for response in [succ, err, failed]:
-            if response is not None:
-                self.assertEqual(num_items, len(response))
-                for index, row in response.iterrows():
-                    self.assertEqual(expected_value[f"{response}"][index], row[response.columns[0]])
-
-
 class CocoonPrinterTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
 
         cls.logger = logger.LusidLogger("debug")
+        
+    def assert_responses(self, num_items, expected_value, succ=None, err=None, failed=None):
+        if succ is not None:
+            self.assertEqual(num_items, len(succ))
+            for index, row in succ.iterrows():
+                self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
+
+        if err is not None:
+            self.assertEqual(num_items, len(err))
+            for index, row in err.iterrows():
+                self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+
+        if failed is not None:
+            self.assertEqual(num_items, len(failed))
+            for index, row in failed.iterrows():
+                self.assertEqual(expected_value["failed"][index], row[failed.columns[0]])
 
     @parameterized.expand(
         [
@@ -249,23 +257,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_instruments_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err, failed=failed)
-        # self.assertEqual(num_items, len(failed))
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["failed"][index], row[failed.columns[0]])
-        #     for index, row in failed.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, failed=failed)
 
     @parameterized.expand(
         [
@@ -282,18 +274,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_portfolios_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err)
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err)
 
     @parameterized.expand(
         [
@@ -310,18 +291,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_transactions_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err)
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err)
 
     @parameterized.expand(
         [
@@ -343,29 +313,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err, failed = format_quotes_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err, failed=failed)
-        # self.assertEqual(num_items, len(failed))
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(
-        #         expected_value["succ"][index],
-        #         row["quote_id.quote_series_id.instrument_id"],
-        #     )
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(
-        #         expected_value["failed"][index],
-        #         row["quote_id.quote_series_id.instrument_id"],
-        #     )
-        #     for index, row in failed.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, failed=failed)
 
     @parameterized.expand(
         [
@@ -382,18 +330,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_holdings_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err)
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err)
 
     @parameterized.expand(
         [
@@ -410,18 +347,7 @@ class CocoonPrinterTests(unittest.TestCase):
         self, _, response, num_items, expected_value
     ):
         succ, err = format_reference_portfolios_response(response)
-        assert_responses(self, num_items, expected_value, succ=succ, err=err)
-        # self.assertEqual(num_items, len(succ))
-        # self.assertEqual(num_items, len(err))
-
-        # [
-        #     self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
-        #     for index, row in succ.iterrows()
-        # ]
-        # [
-        #     self.assertEqual(expected_value["err"][index], row[err.columns[0]])
-        #     for index, row in err.iterrows()
-        # ]
+        self.assert_responses(num_items, expected_value, succ=succ, err=err)
 
     # Test failure cases
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

SE-100: Added a formatting function in cocoon_printer for reference portfolios. Tests also added in test_cocoon_printer.
https://finbourne.atlassian.net/browse/SE-100

