### PR TITLE
Feature/se 146.seed data optional mappings default

### DIFF
--- a/lusidtools/cocoon/seed_sample_data.py
+++ b/lusidtools/cocoon/seed_sample_data.py
@@ -67,7 +67,7 @@ def seed_data(
 
         data_frame = getattr(pd, f"read_{supported_files[file_type]}")(transaction_file)
 
-    def check_or_set_default_value(mapping, key, default_value):
+    def check_or_set_default_value(mapping, check_key, default_value):
         """
         This function check whether the mappings variables have the required default values to be uploaded
         via the load_from_data_frame function.
@@ -77,7 +77,7 @@ def seed_data(
         mapping : dict
             a file containing mapping of DataFrame headers to LUSID headers.
 
-        key : str
+        check_key : str
             a string that represents the key to be checked
 
         default_value : obj
@@ -90,8 +90,9 @@ def seed_data(
 
         """
 
-        if key not in mapping:
-            mapping.update(default_value)
+        for key, value in mapping.items():
+            if check_key not in value.keys():
+                value.update({check_key: default_value})
 
         return mapping
 
@@ -115,6 +116,7 @@ def seed_data(
     overall_results = {}
 
     mappings = check_or_set_default_value(mappings, "optional", {})
+    mappings = check_or_set_default_value(mappings, "identifier_mapping", {})
     mappings = check_or_set_default_value(mappings, "properties", [])
 
     for domain in domains:

--- a/lusidtools/cocoon/seed_sample_data.py
+++ b/lusidtools/cocoon/seed_sample_data.py
@@ -41,7 +41,8 @@ def seed_data(
 
     Returns
     -------
-    None
+    overall_results : dict
+        An object containing the responses for each domain upload.
 
     """
 

--- a/lusidtools/cocoon/seed_sample_data.py
+++ b/lusidtools/cocoon/seed_sample_data.py
@@ -66,33 +66,33 @@ def seed_data(
 
         data_frame = getattr(pd, f"read_{supported_files[file_type]}")(transaction_file)
 
-    def default_optional_mappings(mappings):
+    def check_or_set_default_value(mapping, key, default_value):
         """
-        This function check whether a custom mappings file is provided and if so it makes sure that optional
-        mappings are included, even if the value of the keys are an empty dictionary.
+        This function check whether the mappings variables have the required default values to be uploaded
+        via the load_from_data_frame function.
 
         Parameters
         ----------
-        mappings : dict
+        mapping : dict
             a file containing mapping of DataFrame headers to LUSID headers.
+
+        key : str
+            a string that represents the key to be checked
+
+        default_value : obj
+            an object such as an empty dictionary or list
 
         Returns
         -------
-        mappings : dict
+        mapping : dict
             a file containing mapping of DataFrame headers to LUSID headers.
 
         """
 
-        if mappings == default_mappings:
-            return mappings
+        if key not in mapping:
+            mapping.update(default_value)
 
-        else:
-            for key, value in mappings.items():
-                if "optional" in value.keys():
-                    pass
-                else:
-                    value.update({"optional": {}})
-            return mappings
+        return mapping
 
     def generic_load_from_data_frame(file_type):
 
@@ -113,7 +113,8 @@ def seed_data(
 
     overall_results = {}
 
-    mappings = default_optional_mappings(mappings)
+    mappings = check_or_set_default_value(mappings, "optional", {})
+    mappings = check_or_set_default_value(mappings, "properties", [])
 
     for domain in domains:
 

--- a/lusidtools/cocoon/seed_sample_data.py
+++ b/lusidtools/cocoon/seed_sample_data.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 logger = logging.getLogger()
 
-mappings = dict(load_json_file("config/seed_sample_data.json"))
+default_mappings = dict(load_json_file("config/seed_sample_data.json"))
 
 
 def seed_data(
@@ -15,7 +15,7 @@ def seed_data(
     scope: str,
     transaction_file: str,
     file_type: str,
-    mappings: dict = mappings,
+    mappings: dict = default_mappings,
     sub_holding_keys=[],
 ):
     """
@@ -66,6 +66,34 @@ def seed_data(
 
         data_frame = getattr(pd, f"read_{supported_files[file_type]}")(transaction_file)
 
+    def default_optional_mappings(mappings):
+        """
+        This function check whether a custom mappings file is provided and if so it makes sure that optional
+        mappings are included, even if the value of the keys are an empty dictionary.
+
+        Parameters
+        ----------
+        mappings : dict
+            a file containing mapping of DataFrame headers to LUSID headers.
+
+        Returns
+        -------
+        mappings : dict
+            a file containing mapping of DataFrame headers to LUSID headers.
+
+        """
+
+        if mappings == default_mappings:
+            return mappings
+
+        else:
+            for key, value in mappings.items():
+                if "optional" in value.keys():
+                    pass
+                else:
+                    value.update({"optional": {}})
+            return mappings
+
     def generic_load_from_data_frame(file_type):
 
         return (
@@ -84,6 +112,8 @@ def seed_data(
         )
 
     overall_results = {}
+
+    mappings = default_optional_mappings(mappings)
 
     for domain in domains:
 

--- a/lusidtools/cocoon/seed_sample_data.py
+++ b/lusidtools/cocoon/seed_sample_data.py
@@ -90,8 +90,8 @@ def seed_data(
 
         """
 
-        for key, value in mapping.items():
-            if check_key not in value.keys():
+        for value in mapping.values():
+            if isinstance(value, dict) and check_key not in value.keys():
                 value.update({check_key: default_value})
 
         return mapping

--- a/tests/integration/cocoon/data/seed_sample_data/seed_sample_data_override.json
+++ b/tests/integration/cocoon/data/seed_sample_data/seed_sample_data_override.json
@@ -1,36 +1,46 @@
-{"instruments": {
+{
+  "instruments": {
     "identifier_mapping": {
-        "ClientInternal": "instrument_id",
-        "Ticker": "ticker",
-        "Sedol": "sedol"},
-    "required": {"name": "name"},
-    "properties": ["instrument_type"],
-        "optional": {}
-},"portfolios": {
-        "required": {
-            "code": "portfolio_code",
-            "display_name": "portfolio_name_override",
-            "base_currency": "portfolio_base_currency"
-        },
-        "optional": {"created": "$2000-01-01T00:00:00+00:00"},
-    "identifier_mapping" : {},
-    "properties": []
-    },"transactions":
-    {"identifier_mapping": {
-        "ClientInternal": "instrument_id",
-        "Currency": "cash_transactions"
+      "ClientInternal": "instrument_id",
+      "Ticker": "ticker",
+      "Sedol": "sedol"
     },
     "required": {
-        "code": "portfolio_code",
-        "transaction_id": "txn_id",
-        "type": "txn_type_override",
-        "transaction_price.price": "txn_price",
-        "transaction_price.type": "$Price",
-        "total_consideration.amount": "txn_consideration",
-        "units": "txn_units",
-        "transaction_date": "txn_trade_date",
-        "total_consideration.currency": "currency_override",
-        "settlement_date": "txn_settle_date"
+      "name": "name"
     },
-    "optional": {},
-    "properties": ["strategy"]}}
+    "properties": [
+      "instrument_type"
+    ]
+  },
+  "portfolios": {
+    "required": {
+      "code": "portfolio_code",
+      "display_name": "portfolio_name_override",
+      "base_currency": "portfolio_base_currency"
+    },
+    "optional": {
+      "created": "$2000-01-01T00:00:00+00:00"
+    }
+  },
+  "transactions": {
+    "identifier_mapping": {
+      "ClientInternal": "instrument_id",
+      "Currency": "cash_transactions"
+    },
+    "required": {
+      "code": "portfolio_code",
+      "transaction_id": "txn_id",
+      "type": "txn_type_override",
+      "transaction_price.price": "txn_price",
+      "transaction_price.type": "$Price",
+      "total_consideration.amount": "txn_consideration",
+      "units": "txn_units",
+      "transaction_date": "txn_trade_date",
+      "total_consideration.currency": "currency_override",
+      "settlement_date": "txn_settle_date"
+    },
+    "properties": [
+      "strategy"
+    ]
+  }
+}

--- a/tests/integration/cocoon/test_seed_sample_data.py
+++ b/tests/integration/cocoon/test_seed_sample_data.py
@@ -165,10 +165,11 @@ class CocoonTestSeedDataWithMappingOverrideCSV(
 
         cls.sample_data = pd.read_csv(seed_sample_data_override_csv)
 
-        seed_data(
-            cls.api_factory,
+    def test_override_with_custom_mapping(self):
+        result = seed_data(
+            self.api_factory,
             ["portfolios", "instruments", "transactions"],
-            cls.scope,
+            self.scope,
             seed_sample_data_override_csv,
             mappings=dict(
                 load_json_file(
@@ -181,9 +182,12 @@ class CocoonTestSeedDataWithMappingOverrideCSV(
                     )
                 )
             ),
-            sub_holding_keys=[f"Transaction/{cls.scope}/strategy"],
+            sub_holding_keys=[f"Transaction/{self.scope}/strategy"],
             file_type="csv",
         )
+        self.assertEqual(len(result["portfolios"][0]["portfolios"]["success"]), 1)
+        self.assertEqual(len(result["instruments"][0]["instruments"]["success"]), 1)
+        self.assertEqual(len(result["transactions"][0]["transactions"]["success"]), 1)
 
 
 class CocoonTestSeedDataNoMappingOverrideExcel(


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

When explicitly passing in a mapping to `seed_data` this commit defaults any optional mappings to an empty dict/list if one is not provided. This is a requirement of lpt rather than a requirement of the core API. 
https://finbourne.atlassian.net/browse/SE-146
