### PR TITLE
Feature/se 228

### DIFF
--- a/lusidtools/cocoon/transaction_type_upload.py
+++ b/lusidtools/cocoon/transaction_type_upload.py
@@ -58,3 +58,91 @@ def create_transaction_type_configuration(api_factory, alias, movements):
     )
 
     return response
+
+
+def replace_current_transaction_alias(
+    api_factory, updated_alias, movements, properties=None
+):
+
+    """
+    This function overrides the current transaction types alias with a new configuration
+
+    Parameters
+    ----------
+    api_factory: lusid.utilities.ClientApiFactory
+        The LUSID api factory to use.
+    updated_alias: lusid.models.TransactionConfigurationTypeAlias
+        The alias which we want to update.
+    movements: list[lusid.models.TransactionConfigurationMovementDataRequest]
+        The movements to use for transaction type
+    properties: dict[str, lusid.PerpetualProperty]
+        The custom properties to assign to the transaction type
+
+    Returns
+    -------
+    response : (lusid.models.TransactionSetConfigurationData)
+        The response from setting the transaction type
+    """
+
+    # Call LUSID to get a list of the current transaction types
+
+    current_transaction_types = api_factory.build(
+        lusid.api.SystemConfigurationApi
+    ).list_configuration_transaction_types()
+
+    transaction_configs_list = current_transaction_types.transaction_configs
+
+    # Build the new transaction type you want to upload
+
+    new_transaction_request = models.TransactionConfigurationDataRequest(
+        aliases=[updated_alias], movements=movements, properties=properties,
+    )
+
+    # Delete the current configuration assigned to your replacement alias
+
+    for txn_index, trans_type in enumerate(transaction_configs_list):
+
+        find_new_alias = False
+
+        for alias_index, alias in enumerate(trans_type.aliases):
+
+            if (
+                alias.type == updated_alias.type
+                and alias.transaction_group == updated_alias.transaction_group
+            ):
+
+                del trans_type.aliases[alias_index]
+
+                find_new_alias = True
+
+                break
+
+        else:
+            continue
+
+        # If there are no aliases assigned against the old movement, delete the transaction type configuration from LUSID
+        # We don't want to leave unassigned movements in LUSID
+
+        if len(trans_type.aliases) == 0:
+            del transaction_configs_list[txn_index]
+
+        break
+
+    if find_new_alias is False:
+
+        raise Warning(
+            "The requested alias is not available in LUSID. No updates have been made."
+        )
+
+    transaction_configs_list.append(new_transaction_request)
+
+    set_response = api_factory.build(
+        lusid.api.SystemConfigurationApi
+    ).set_configuration_transaction_types(
+        transaction_set_configuration_data_request=models.TransactionSetConfigurationDataRequest(
+            transaction_config_requests=transaction_configs_list,
+            side_config_requests=current_transaction_types.side_definitions,
+        )
+    )
+
+    return set_response

--- a/tests/integration/cocoon/test_replace_current_transaction_alias.py
+++ b/tests/integration/cocoon/test_replace_current_transaction_alias.py
@@ -1,0 +1,138 @@
+import unittest
+from pathlib import Path
+import lusid
+import lusid.models as models
+from lusidtools.cocoon.utilities import create_scope_id
+from lusidtools.cocoon.transaction_type_upload import replace_current_transaction_alias
+import logging
+
+logger = logging.getLogger()
+new_transaction_type = create_scope_id().replace("-", "")
+
+
+class CocoonTestTransactionTypeUpload(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+
+        secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
+        cls.api_factory = lusid.utilities.ApiClientFactory(
+            api_secrets_filename=secrets_file
+        )
+
+        cls.system_configuration_api = cls.api_factory.build(
+            lusid.api.SystemConfigurationApi
+        )
+
+        cls.alias = [
+            models.TransactionConfigurationTypeAlias(
+                type=new_transaction_type,
+                description="TESTBUY1",
+                transaction_class="TESTBUY1",
+                transaction_group="SYSTEM1",
+                transaction_roles="AllRoles",
+            )
+        ]
+
+        cls.movements = [
+            models.TransactionConfigurationMovementData(
+                movement_types="StockMovement",
+                side="Side1",
+                direction=1,
+                properties={},
+                mappings=[],
+            ),
+            models.TransactionConfigurationMovementData(
+                movement_types="CashCommitment",
+                side="Side2",
+                direction=1,
+                properties={},
+                mappings=[],
+            ),
+        ]
+
+        cls.create_transaction_response = cls.system_configuration_api.create_configuration_transaction_type(
+            transaction_configuration_data_request=models.TransactionConfigurationDataRequest(
+                aliases=cls.alias, movements=cls.movements
+            )
+        )
+
+    def test_update_current_alias_with_new_movements(self):
+
+        updated_movements = [
+            models.TransactionConfigurationMovementData(
+                movement_types="StockMovement",
+                side="Side1",
+                direction=1,
+                properties={},
+                mappings=[],
+            ),
+            models.TransactionConfigurationMovementData(
+                movement_types="CashCommitment",
+                side="Side2",
+                direction=1,
+                properties={},
+                mappings=[],
+            ),
+        ]
+
+        replace_current_transaction_alias(
+            api_factory=self.api_factory,
+            updated_alias=self.alias[0],
+            movements=updated_movements,
+        )
+
+        get_transaction_types = (
+            self.system_configuration_api.list_configuration_transaction_types()
+        )
+
+        uploaded_alias = []
+
+        for trans_type in get_transaction_types.transaction_configs:
+            for alias in trans_type.aliases:
+                if alias.type == new_transaction_type:
+                    uploaded_alias.append(trans_type)
+
+        alias_for_test = models.TransactionConfigurationData(
+            aliases=self.alias, movements=updated_movements, properties={}
+        )
+
+        self.assertEqual(uploaded_alias[0], alias_for_test)
+
+    def test_update_alias_which_does_not_exist(self):
+
+        updated_movements = [
+            models.TransactionConfigurationMovementData(
+                movement_types="StockMovement",
+                side="Side1",
+                direction=-1,
+                properties={},
+                mappings=[],
+            ),
+            models.TransactionConfigurationMovementData(
+                movement_types="CashCommitment",
+                side="Side2",
+                direction=1,
+                properties={},
+                mappings=[],
+            ),
+        ]
+
+        updated_alias = models.TransactionConfigurationTypeAlias(
+            type=create_scope_id().replace("-", ""),
+            description="TESTBUY1",
+            transaction_class="TESTBUY1",
+            transaction_group="SYSTEM1",
+            transaction_roles="AllRoles",
+        )
+
+        with self.assertRaises(Warning) as error:
+            replace_current_transaction_alias(
+                api_factory=self.api_factory,
+                updated_alias=updated_alias,
+                movements=updated_movements,
+            )
+
+        self.assertEqual(
+            error.exception.args[0],
+            "The requested alias is not available in LUSID. No updates have been made.",
+        )


### PR DESCRIPTION
# Pull Request Checklist

- [ x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ x] Tests pass

# Description of the PR

This PR has new function which has the impact of amending a current transaction type configuration.

The function works as follows:

(1) Query all available transaction types in LUSID
(2) Check if the alias exists
(3) If alias does not already exist, throw a Warning
(4) If alias does exist, delete the current configuration and replace with configuration defined in function
(5) Set the new config 
