### PR TITLE
Feature/se 275.lpt accept hardcoded int

### DIFF
--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -858,7 +858,7 @@ def handle_nested_default_and_column_mapping(
             raise ValueError(
                 f"""You have passed in a value with type {type(value)} for the mapping for {key}, this is
                                  not a supported type. Please provide a string with the column name to use, a constant
-                                 value prefixed by {constant_prefix} or a dictionary
+                                 value prefixed by {constant_prefix},an integer value or a dictionary
                                  with the keys "column" and "default" where column is the column name and default
                                  being the default value to use."""
             )

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -850,6 +850,10 @@ def handle_nested_default_and_column_mapping(
                 mapping_updated[key] = f"LUSID.{key}"
                 data_frame[mapping_updated[key]] = value[1:]
 
+        elif isinstance(value, int):
+            mapping_updated[key] = f"LUSID.{key}"
+            data_frame[mapping_updated[key]] = value
+
         else:
             raise ValueError(
                 f"""You have passed in a value with type {type(value)} for the mapping for {key}, this is

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -498,6 +498,62 @@ class CocoonTestsHoldings(unittest.TestCase):
                 False,
                 lusid.models.Version,
             ],
+            [
+                "Pass string as tax_lots.units value",
+                "prime_broker_test",
+                "data/holdings-example-unique-date-duplicate-column.csv",
+                {
+                    "code": "FundCode",
+                    "effective_at": "Effective Date",
+                    "tax_lots.units": "$1",
+                },
+                {
+                    "tax_lots.cost.amount": None,
+                    "tax_lots.cost.currency": "Local Currency Code",
+                    "tax_lots.portfolio_cost": None,
+                    "tax_lots.price": None,
+                    "tax_lots.purchase_date": None,
+                    "tax_lots.settlement_date": None,
+                },
+                {
+                    "Isin": "ISIN Security Identifier",
+                    "Sedol": "SEDOL Security Identifier",
+                    "Currency": "is_cash_with_currency",
+                },
+                ["Prime Broker"],
+                "operations001",
+                None,
+                False,
+                lusid.models.Version,
+            ],
+            [
+                "Pass integer as tax_lots.units value",
+                "prime_broker_test",
+                "data/holdings-example-unique-date-duplicate-column.csv",
+                {
+                    "code": "FundCode",
+                    "effective_at": "Effective Date",
+                    "tax_lots.units": 1,
+                },
+                {
+                    "tax_lots.cost.amount": None,
+                    "tax_lots.cost.currency": "Local Currency Code",
+                    "tax_lots.portfolio_cost": None,
+                    "tax_lots.price": None,
+                    "tax_lots.purchase_date": None,
+                    "tax_lots.settlement_date": None,
+                },
+                {
+                    "Isin": "ISIN Security Identifier",
+                    "Sedol": "SEDOL Security Identifier",
+                    "Currency": "is_cash_with_currency",
+                },
+                ["Prime Broker"],
+                "operations001",
+                None,
+                False,
+                lusid.models.Version,
+            ],
         ]
     )
     def test_load_from_data_frame_holdings_success(


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Allows for hard-coded integers to be passed as integers into LTP mappings, rather than as strings with the $ constant prefix. 
