### PR TITLE
SE-189: Add Upsert Portfolio to command line apps & update existing apps

### DIFF
--- a/lusidtools/apps/__init__.py
+++ b/lusidtools/apps/__init__.py
@@ -2,3 +2,4 @@ from lusidtools.apps.upsert_instruments import load_instruments
 from lusidtools.apps.upsert_holdings import load_holdings
 from lusidtools.apps.upsert_transactions import load_transactions
 from lusidtools.apps.upsert_quotes import load_quotes
+from lusidtools.apps.upsert_portfolios import load_portfolios

--- a/lusidtools/apps/upsert_instruments.py
+++ b/lusidtools/apps/upsert_instruments.py
@@ -51,16 +51,13 @@ def load_instruments(args):
         api_factory=factory,
         data_frame=instruments,
         scope=args["scope"],
+        properties_scope=args.get("property_scope", args["scope"]),
         mapping_required=mappings[file_type]["required"],
-        mapping_optional=mappings[file_type]["optional"]
-        if "optional" in mappings[file_type].keys()
-        else {},
+        mapping_optional=mappings[file_type].get("optional", {}),
         file_type=file_type,
         identifier_mapping=mappings[file_type]["identifier_mapping"],
         batch_size=args["batch_size"],
-        property_columns=mappings[file_type]["property_columns"]
-        if "property_columns" in mappings[file_type].keys()
-        else [],
+        property_columns=mappings[file_type].get("property_columns", []),
     )
 
     succ, errors, failed = cocoon_printer.format_instruments_response(

--- a/lusidtools/apps/upsert_portfolios.py
+++ b/lusidtools/apps/upsert_portfolios.py
@@ -7,39 +7,35 @@ from lusidtools.cocoon import (
     parse_args,
     load_data_to_df_and_detect_delimiter,
     load_from_data_frame,
-    identify_cash_items,
     validate_mapping_file_structure,
     load_json_file,
     cocoon_printer,
 )
 
 
-def load_holdings(args):
-    file_type = "holdings"
+def load_portfolios(args):
+    file_type = "portfolios"
 
     factory = ApiClientFactory(api_secrets_filename=args["secrets_file"])
 
     if args["delimiter"]:
         logging.info(f"delimiter specified as {repr(args['delimiter'])}")
     logging.debug("Getting data")
-    holdings = load_data_to_df_and_detect_delimiter(args)
+    portfolios = load_data_to_df_and_detect_delimiter(args)
 
     mappings = load_json_file(args["mapping"])
-    if "cash_flag" in mappings.keys():
-        holdings, mappings = identify_cash_items(holdings, mappings, file_type)
 
-    validate_mapping_file_structure(mappings, holdings.columns, file_type)
+    validate_mapping_file_structure(mappings, portfolios.columns, file_type)
 
     if args["dryrun"]:
         logging.info("--dryrun specified as True, exiting before upsert call is made")
         return 0
 
-    holdings_response = load_from_data_frame(
+    portfolios_response = load_from_data_frame(
         api_factory=factory,
-        data_frame=holdings,
+        data_frame=portfolios,
         scope=args["scope"],
         properties_scope=args.get("property_scope", args["scope"]),
-        identifier_mapping=mappings[file_type]["identifier_mapping"],
         mapping_required=mappings[file_type]["required"],
         mapping_optional=mappings[file_type].get("optional", {}),
         file_type=file_type,
@@ -48,7 +44,7 @@ def load_holdings(args):
         sub_holding_keys=mappings[file_type].get("sub_holding_keys", []),
     )
 
-    succ, errors = cocoon_printer.format_holdings_response(holdings_response)
+    succ, errors = cocoon_printer.format_portfolios_response(portfolios_response)
 
     logging.info(f"number of successful upserts: {len(succ)}")
     logging.info(f"number of errors            : {len(errors)}")
@@ -57,13 +53,13 @@ def load_holdings(args):
         logging.info(succ.head(40))
         logging.info(errors.head(40))
 
-    return holdings_response
+    return portfolios_response
 
 
 def main():
     args, ap = parse_args(sys.argv[1:])
     LusidLogger(args["debug"])
-    load_holdings(args)
+    load_portfolios(args)
 
     return 0
 

--- a/lusidtools/apps/upsert_quotes.py
+++ b/lusidtools/apps/upsert_quotes.py
@@ -54,16 +54,13 @@ def load_quotes(args):
         api_factory=factory,
         data_frame=quotes,
         scope=args["scope"],
+        properties_scope=args.get("property_scope", args["scope"]),
         identifier_mapping={},
         mapping_required=mappings[file_type]["required"],
-        mapping_optional=mappings[file_type]["optional"]
-        if "optional" in mappings[file_type].keys()
-        else {},
+        mapping_optional=mappings[file_type].get("optional", {}),
         file_type=file_type,
         batch_size=args["batch_size"],
-        property_columns=mappings[file_type]["property_columns"]
-        if "property_columns" in mappings[file_type].keys()
-        else [],
+        property_columns=mappings[file_type].get("property_columns", []),
     )
     succ, errors, failed = cocoon_printer.format_quotes_response(quotes_response)
     logging.info(f"number of successful upserts: {len(succ)}")

--- a/lusidtools/apps/upsert_transactions.py
+++ b/lusidtools/apps/upsert_transactions.py
@@ -39,16 +39,13 @@ def load_transactions(args):
         api_factory=factory,
         data_frame=transactions,
         scope=args["scope"],
+        properties_scope=args.get("property_scope", args["scope"]),
         identifier_mapping=mappings[file_type]["identifier_mapping"],
         mapping_required=mappings[file_type]["required"],
-        mapping_optional=mappings[file_type]["optional"]
-        if "optional" in mappings[file_type].keys()
-        else {},
+        mapping_optional=mappings[file_type].get("optional", {}),
         file_type=file_type,
         batch_size=args["batch_size"],
-        property_columns=mappings[file_type]["property_columns"]
-        if "property_columns" in mappings[file_type].keys()
-        else [],
+        property_columns=mappings[file_type].get("property_columns", []),
     )
 
     # print_response(transactions_response, file_type)

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -1010,6 +1010,9 @@ def parse_args(args: dict):
     )
     ap.add_argument("-s", "--scope", help=r"LUSID scope to act in")
     ap.add_argument(
+        "-ps", "--property_scope", help=r"LUSID scope to load properties into"
+    )
+    ap.add_argument(
         "-dl",
         "--delimiter",
         help=r"explicitly specify delimiter for data file and disable automatic delimiter detection",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     python_requires=">=3.7",
     entry_points={
         "console_scripts": [
+            "upsert_portfolios=lusidtools.apps.upsert_portfolios:main",
             "lusidtools=lusidtools.commands.commands:main",
             "upsert_instruments=lusidtools.apps.upsert_instruments:main",
             "upsert_holdings=lusidtools.apps.upsert_holdings:main",

--- a/tests/integration/apps/test_data/mapping_port.json
+++ b/tests/integration/apps/test_data/mapping_port.json
@@ -1,0 +1,10 @@
+{
+  "portfolios": {
+        "required": {
+            "code": "$temp_upsert_portfolios_lpt",
+            "display_name":  "$temp_portfolio for lpt tests - should be deleted by test",
+            "base_currency": "$GBP",
+            "created": "$2018-01-01T00:00:00+00:00"
+        }
+    }
+}


### PR DESCRIPTION
DEV-189: update tests

# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

- Adds the property scope argument to the command line apps, which defaults to the scope argument if not specified 
- Updates the optional load from dataframe parameters with dict.get([something], [default])
- Adds a command line app to create portfolios