### PR TITLE
SE-454: Add Test for upsert Lookthough portfolio ID

### DIFF
--- a/lusidtools/lpt/search_instruments.py
+++ b/lusidtools/lpt/search_instruments.py
@@ -35,7 +35,7 @@ def process_args(api, args):
         api.models.InstrumentSearchProperty(s[0], s[1])
         for s in [p.split("=") for p in args.properties]
     ]
-    return api.call.instruments_search(symbols=request, mastered_only=True).bind(
+    return api.call.instruments_search(instrument_search_property=request, mastered_only=True).bind(
         success
     )
 

--- a/lusidtools/lpt/search_instruments.py
+++ b/lusidtools/lpt/search_instruments.py
@@ -35,9 +35,9 @@ def process_args(api, args):
         api.models.InstrumentSearchProperty(s[0], s[1])
         for s in [p.split("=") for p in args.properties]
     ]
-    return api.call.instruments_search(instrument_search_property=request, mastered_only=True).bind(
-        success
-    )
+    return api.call.instruments_search(
+        instrument_search_property=request, mastered_only=True
+    ).bind(success)
 
 
 # Standalone tool

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -1081,36 +1081,29 @@ class CocoonTestsInstruments(unittest.TestCase):
 
         data_frame = pd.DataFrame(
             {
-                "instrument_name": [
-                    "Portfolio",
-                ],
+                "instrument_name": ["Portfolio",],
                 "client_internal": [code],
-                "lookthrough_code": [code]
+                "lookthrough_code": [code],
             }
         )
 
         mapping = {
-            "identifier_mapping": {
-                "ClientInternal": "client_internal",
-            },
-            "required": {
-                "name": "instrument_name"
-            },
+            "identifier_mapping": {"ClientInternal": "client_internal",},
+            "required": {"name": "instrument_name"},
             "optional": {
                 "look_through_portfolio_id.scope": f"${scope}",
-                "look_through_portfolio_id.code": "lookthrough_code"
-            }
+                "look_through_portfolio_id.code": "lookthrough_code",
+            },
         }
 
         # create portfolio
-        port_response = self.api_factory.build(lusid.api.TransactionPortfoliosApi).create_portfolio(
+        port_response = self.api_factory.build(
+            lusid.api.TransactionPortfoliosApi
+        ).create_portfolio(
             scope=scope,
             create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
-                display_name=code,
-                description=code,
-                code=code,
-                base_currency="USD"
-            )
+                display_name=code, description=code, code=code, base_currency="USD"
+            ),
         )
 
         # Upsert lookthrough instrument of portfolio
@@ -1122,11 +1115,14 @@ class CocoonTestsInstruments(unittest.TestCase):
             mapping_optional=mapping["optional"],
             file_type="instruments",
             identifier_mapping=mapping["identifier_mapping"],
-            property_columns=[]
+            property_columns=[],
         )
 
         self.assertEqual(len(instr_response["instruments"]["success"]), 1)
         self.assertEqual(len(instr_response["instruments"]["errors"]), 0)
-        self.assertEqual(instr_response["instruments"]["success"][0].values[f"ClientInternal: {code}"].lookthrough_portfolio.code, code)
-
-
+        self.assertEqual(
+            instr_response["instruments"]["success"][0]
+            .values[f"ClientInternal: {code}"]
+            .lookthrough_portfolio.code,
+            code,
+        )

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -233,7 +233,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 {},
                 ["base_currency"],
                 "operations001",
-                None
+                None,
             ],
         ]
     )
@@ -268,15 +268,17 @@ class CocoonTestsPortfolios(unittest.TestCase):
 
         with self.assertRaises(ApiValueError):
 
-            responses = cocoon.cocoon.load_from_data_frame(
-                api_factory=self.api_factory,
-                scope=scope,
-                data_frame=data_frame,
-                mapping_required=mapping_required,
-                mapping_optional=mapping_optional,
-                file_type="portfolios",
-                identifier_mapping=identifier_mapping,
-                property_columns=property_columns,
-                properties_scope=properties_scope,
-                sub_holding_keys=sub_holding_keys,
-            ),
+            responses = (
+                cocoon.cocoon.load_from_data_frame(
+                    api_factory=self.api_factory,
+                    scope=scope,
+                    data_frame=data_frame,
+                    mapping_required=mapping_required,
+                    mapping_optional=mapping_optional,
+                    file_type="portfolios",
+                    identifier_mapping=identifier_mapping,
+                    property_columns=property_columns,
+                    properties_scope=properties_scope,
+                    sub_holding_keys=sub_holding_keys,
+                ),
+            )

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -220,7 +220,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
     @parameterized.expand(
         [
             [
-                "400 bad request due to an invalid scope",
+                "ApiValueError due to invalid scope",
                 "p rime_broker_test",
                 "data/metamorph_portfolios-unique.csv",
                 {
@@ -233,8 +233,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 {},
                 ["base_currency"],
                 "operations001",
-                None,
-                {400},
+                None
             ],
         ]
     )
@@ -249,7 +248,6 @@ class CocoonTestsPortfolios(unittest.TestCase):
         property_columns,
         properties_scope,
         sub_holding_keys,
-        expected_outcome,
     ) -> None:
         """
         Test that portfolios can be loaded successfully
@@ -266,31 +264,19 @@ class CocoonTestsPortfolios(unittest.TestCase):
         :return: None
         """
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
+        from lusid.exceptions import ApiValueError
 
-        responses = cocoon.cocoon.load_from_data_frame(
-            api_factory=self.api_factory,
-            scope=scope,
-            data_frame=data_frame,
-            mapping_required=mapping_required,
-            mapping_optional=mapping_optional,
-            file_type="portfolios",
-            identifier_mapping=identifier_mapping,
-            property_columns=property_columns,
-            properties_scope=properties_scope,
-            sub_holding_keys=sub_holding_keys,
-        )
+        with self.assertRaises(ApiValueError):
 
-        self.assertEqual(
-            first=len(responses["portfolios"]["errors"]), second=len(data_frame)
-        )
-
-        self.assertEqual(first=len(responses["portfolios"]["success"]), second=0)
-
-        response_codes = set(
-            [
-                api_exception.status
-                for api_exception in responses["portfolios"]["errors"]
-            ]
-        )
-
-        self.assertEqual(first=response_codes, second=expected_outcome)
+            responses = cocoon.cocoon.load_from_data_frame(
+                api_factory=self.api_factory,
+                scope=scope,
+                data_frame=data_frame,
+                mapping_required=mapping_required,
+                mapping_optional=mapping_optional,
+                file_type="portfolios",
+                identifier_mapping=identifier_mapping,
+                property_columns=property_columns,
+                properties_scope=properties_scope,
+                sub_holding_keys=sub_holding_keys,
+            ),

--- a/tests/unit/pandas_utils/test_lusid_pandas.py
+++ b/tests/unit/pandas_utils/test_lusid_pandas.py
@@ -364,7 +364,7 @@ class TestResponseToPandasObject(unittest.TestCase):
             lusid_response_to_data_frame(list_response)
 
         self.assertEqual(
-            error.exception.args[0], "All items in list must be of same data type",
+            error.exception.args[0], 'All items in list must be of the same data type',
         )
 
     def test_list_of_same_lusid_objects_no_to_dict(self):

--- a/tests/unit/pandas_utils/test_lusid_pandas.py
+++ b/tests/unit/pandas_utils/test_lusid_pandas.py
@@ -364,7 +364,7 @@ class TestResponseToPandasObject(unittest.TestCase):
             lusid_response_to_data_frame(list_response)
 
         self.assertEqual(
-            error.exception.args[0], 'All items in list must be of the same data type',
+            error.exception.args[0], "All items in list must be of the same data type",
         )
 
     def test_list_of_same_lusid_objects_no_to_dict(self):


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

- Fix search instruments - replace symbols parameter with instrument_search_property
- Fix error message for LUSID exceptions - 'All items in list must be of the same data type'
- Added Test for upsert Lookthough portfolio ID
- Update cocoon upsert portfolio with invalid scope failure test (used to return 400, now it returns lusid.exceptions.ApiValueError)
