### PR TITLE
SE-465: Fix mixed lookthrough instrument upload

### DIFF
--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -254,6 +254,7 @@ def set_attributes_recursive(
     # Used to check if all attributes are none
     total_count = 0
     none_count = 0
+    missing_value = False
 
     # For each of the attributes to populate
     for key in list(populate_attributes):
@@ -281,6 +282,8 @@ def set_attributes_recursive(
                     obj_init_values[key] = str(DateOrCutLabel(row[mapping[key]]))
                 else:
                     obj_init_values[key] = row[mapping[key]]
+            else:
+                missing_value = True
 
         # if there is more nesting call the function recursively
         else:
@@ -302,8 +305,9 @@ def set_attributes_recursive(
     If all attributes are None propagate None rather than a model filled with Nones. For example if a CorporateActionSourceId
     has no scope or code return build a model with CorporateActionSourceId = None rather than CorporateActionSourceId = 
     lusid.models.ResourceId(scope=None, code=None)
+    
     """
-    if total_count == none_count:
+    if total_count == none_count or missing_value:
         return None
 
     # Create an instance of and populate the model object


### PR DESCRIPTION
SE-465: Initial fix


SE-465: Add tests for lookthrough instruments upsert
Allow non lookthrough and lookthrough instruments to be upserted in the same dataframe.

# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

when calling load_from_data_frame() with missing lookthough code and scope values in a dataframe, set_attributes_recursive() was populating look_through_portfolio_id=ResourceID(None, None) instead of look_through_portfolio_id=None.

This code change returns None instead of ResourceID(None, None)
