### PR TITLE
SE-465: Fix mixed lookthrough instrument upload

### DIFF
--- a/.github/workflows/bump-version-and-publish.yml
+++ b/.github/workflows/bump-version-and-publish.yml
@@ -41,4 +41,26 @@ jobs:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}    
         run: |
           bash ci_tools/publish.sh "$PYPI_USERNAME" "$PYPI_PASSWORD"
+          
+      - name: Get new package version
+        run: |
+         curl https://raw.githubusercontent.com/finbourne/lusid-python-tools/master/__version__.py | grep __version__ |  awk '{split($0, a, "="); print a[2]}' | tr -d ' "' >> $PYPI_VERSION
+          
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+            username: 'github-actions-tests',
+            icon_emoji: ':octocat:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_REPO} version ${process.env.PYPI_VERSION} has been published to PyPi`
+            }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: success()
     

--- a/.github/workflows/run-tests-on-pull.yml
+++ b/.github/workflows/run-tests-on-pull.yml
@@ -81,7 +81,7 @@ jobs:
             icon_emoji: ':octocat:',
             attachments: [{
               color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text: `Job ${process.env.AS_WORKFLOW}(${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+              text: `Job ${process.env.AS_WORKFLOW}(${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.GITHUB_BASE_REF} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
             }]
             }
         env:

--- a/.github/workflows/run-tests-on-pull.yml
+++ b/.github/workflows/run-tests-on-pull.yml
@@ -81,7 +81,7 @@ jobs:
             icon_emoji: ':octocat:',
             attachments: [{
               color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text: `Job ${process.env.AS_WORKFLOW}(Commit ${process.env.AS_COMMIT} into ${process.env.GITHUB_BASE_REF} from ${process.env.GITHUB_HEAD_REF}) of ${process.env.AS_REPO} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+              text: `Job ${process.env.AS_WORKFLOW} (Commit ${process.env.AS_COMMIT} into ${process.env.GITHUB_BASE_REF} from ${process.env.GITHUB_HEAD_REF}) of ${process.env.AS_REPO} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
             }]
             }
         env:

--- a/.github/workflows/run-tests-on-pull.yml
+++ b/.github/workflows/run-tests-on-pull.yml
@@ -81,7 +81,7 @@ jobs:
             icon_emoji: ':octocat:',
             attachments: [{
               color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text: `Job ${process.env.AS_WORKFLOW}(${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.GITHUB_BASE_REF} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+              text: `Job ${process.env.AS_WORKFLOW}(Commit ${process.env.AS_COMMIT} into ${process.env.GITHUB_BASE_REF} from ${process.env.GITHUB_HEAD_REF}) of ${process.env.AS_REPO} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
             }]
             }
         env:

--- a/.github/workflows/run-tests-on-pull.yml
+++ b/.github/workflows/run-tests-on-pull.yml
@@ -69,3 +69,21 @@ jobs:
           FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
         run: | 
           python -m unittest discover -v
+          
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+            username: 'github-actions',
+            icon_emoji: ':octocat:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `Job ${process.env.AS_WORKFLOW}(${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+            }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -282,7 +282,7 @@ def set_attributes_recursive(
                     obj_init_values[key] = str(DateOrCutLabel(row[mapping[key]]))
                 else:
                     obj_init_values[key] = row[mapping[key]]
-            else:
+            elif mapping[key]:
                 missing_value = True
 
         # if there is more nesting call the function recursively

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -254,6 +254,7 @@ def set_attributes_recursive(
     # Used to check if all attributes are none
     total_count = 0
     none_count = 0
+    missing_value = False
 
     # For each of the attributes to populate
     for key in list(populate_attributes):
@@ -281,6 +282,8 @@ def set_attributes_recursive(
                     obj_init_values[key] = str(DateOrCutLabel(row[mapping[key]]))
                 else:
                     obj_init_values[key] = row[mapping[key]]
+            else:
+                missing_value = True
 
         # if there is more nesting call the function recursively
         else:
@@ -302,8 +305,9 @@ def set_attributes_recursive(
     If all attributes are None propagate None rather than a model filled with Nones. For example if a CorporateActionSourceId
     has no scope or code return build a model with CorporateActionSourceId = None rather than CorporateActionSourceId = 
     lusid.models.ResourceId(scope=None, code=None)
+    
     """
-    if total_count == none_count:
+    if total_count == none_count or missing_value:
         return None
 
     # Create an instance of and populate the model object

--- a/tests/integration/cocoon/data/lookthrough_instr_tests/load_lookthrough_instrument.csv
+++ b/tests/integration/cocoon/data/lookthrough_instr_tests/load_lookthrough_instrument.csv
@@ -1,0 +1,2 @@
+﻿instrument_name,client_internal,lookthrough_code,lookthrough_scope
+Portfolio001,replace_code,replace_code,replace_scope

--- a/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_instruments_default_scope.csv
+++ b/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_instruments_default_scope.csv
@@ -1,0 +1,3 @@
+﻿instrument_name,client_internal,lookthrough_code
+Portfolio001,replace_code,replace_code
+instr_0001,id_0001,

--- a/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv
+++ b/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv
@@ -1,0 +1,3 @@
+﻿instrument_name,client_internal,lookthrough_code,lookthrough_scope
+Portfolio001,replace_code,replace_code,replace_scope
+instr_0001,id_0001,,

--- a/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv
+++ b/tests/integration/cocoon/data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv
@@ -1,0 +1,5 @@
+﻿instrument_name,client_internal,lookthrough_code
+Portfolio001,replace_code,replace_code
+Portfolio002,replace_code2,replace_code2
+instr_0001,id_0001,
+instr_0002,id_0002,

--- a/tests/integration/cocoon/data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv
+++ b/tests/integration/cocoon/data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv
@@ -1,0 +1,3 @@
+﻿instrument_name,client_internal,lookthrough_code,lookthrough_scope
+Portfolio001,replace_code,replace_code,replace_scope
+Portfolio002,replace_code2,replace_code,replace_scope

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -283,7 +283,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             ]
         ]
     )
-    @unittest.skip("--")
     def test_load_from_data_frame_instruments_enrichment_success(
         self,
         _,
@@ -569,22 +568,23 @@ class CocoonTestsInstruments(unittest.TestCase):
         [
             [
                 "load only lookthrough instruments",
-                pd.DataFrame(
-                    {
-                        "instrument_name": [
-                            "Portfolio001",
-                        ],
-                        "client_internal": [
-                            "replace_code",
-                        ],
-                        "lookthrough_code": [
-                            "replace_code",
-                        ],
-                        "lookthrough_scope": [
-                            "replace_scope",
-                        ]
-                    }
-                ),
+                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/load_lookthrough_instrument.csv"),
+                # pd.DataFrame(
+                #     {
+                #         "instrument_name": [
+                #             "Portfolio001",
+                #         ],
+                #         "client_internal": [
+                #             "replace_code",
+                #         ],
+                #         "lookthrough_code": [
+                #             "replace_code",
+                #         ],
+                #         "lookthrough_scope": [
+                #             "replace_scope",
+                #         ]
+                #     }
+                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -600,26 +600,27 @@ class CocoonTestsInstruments(unittest.TestCase):
             ],
             [
                 "load mixed lookthrough instruments",
-                pd.DataFrame(
-                    {
-                        "instrument_name": [
-                            "Portfolio001",
-                            "instr_0001",
-                        ],
-                        "client_internal": [
-                            "replace_code",
-                            "id_0001"
-                        ],
-                        "lookthrough_code": [
-                            "replace_code",
-                            None
-                        ],
-                        "lookthrough_scope": [
-                            "replace_scope",
-                            None
-                        ]
-                    }
-                ),
+                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv"),
+                # pd.DataFrame(
+                #     {
+                #         "instrument_name": [
+                #             "Portfolio001",
+                #             "instr_0001",
+                #         ],
+                #         "client_internal": [
+                #             "replace_code",
+                #             "id_0001"
+                #         ],
+                #         "lookthrough_code": [
+                #             "replace_code",
+                #             None
+                #         ],
+                #         "lookthrough_scope": [
+                #             "replace_scope",
+                #             None
+                #         ]
+                #     }
+                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -635,22 +636,23 @@ class CocoonTestsInstruments(unittest.TestCase):
             ],
             [
                 "load mixed lookthrough instruments with default scope",
-                pd.DataFrame(
-                    {
-                        "instrument_name": [
-                            "Portfolio001",
-                            "instr_0001",
-                        ],
-                        "client_internal": [
-                            "replace_code",
-                            "id_0001"
-                        ],
-                        "lookthrough_code": [
-                            "replace_code",
-                            None
-                        ]
-                    }
-                ),
+                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_instruments_default_scope.csv"),
+                # pd.DataFrame(
+                #     {
+                #         "instrument_name": [
+                #             "Portfolio001",
+                #             "instr_0001",
+                #         ],
+                #         "client_internal": [
+                #             "replace_code",
+                #             "id_0001"
+                #         ],
+                #         "lookthrough_code": [
+                #             "replace_code",
+                #             None
+                #         ]
+                #     }
+                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -659,35 +661,36 @@ class CocoonTestsInstruments(unittest.TestCase):
                         "name": "instrument_name"
                     },
                     "optional": {
-                        "look_through_portfolio_id.scope": "$test-mixed-lookthrough",
+                        "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
                         "look_through_portfolio_id.code": "lookthrough_code"
                     }
                 }
             ],
             [
                 "load mixed lookthrough instruments with default scope with multiple portfolios",
-                pd.DataFrame(
-                    {
-                        "instrument_name": [
-                            "Portfolio001",
-                            "Portfolio002",
-                            "instr_0001",
-                            "instr_0002",
-                        ],
-                        "client_internal": [
-                            "replace_code",
-                            "replace_code2",
-                            "id_0001",
-                            "id_0002"
-                        ],
-                        "lookthrough_code": [
-                            "replace_code",
-                            "replace_code2",
-                            None,
-                            None
-                        ]
-                    }
-                ),
+                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv"),
+                # pd.DataFrame(
+                #     {
+                #         "instrument_name": [
+                #             "Portfolio001",
+                #             "Portfolio002",
+                #             "instr_0001",
+                #             "instr_0002",
+                #         ],
+                #         "client_internal": [
+                #             "replace_code",
+                #             "replace_code2",
+                #             "id_0001",
+                #             "id_0002"
+                #         ],
+                #         "lookthrough_code": [
+                #             "replace_code",
+                #             "replace_code2",
+                #             None,
+                #             None
+                #         ]
+                #     }
+                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -696,7 +699,39 @@ class CocoonTestsInstruments(unittest.TestCase):
                         "name": "instrument_name"
                     },
                     "optional": {
-                        "look_through_portfolio_id.scope": "$test-mixed-lookthrough",
+                        "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
+                        "look_through_portfolio_id.code": "lookthrough_code"
+                    }
+                }
+            ],
+            [
+                "multiple_instruments_with_same_portfolio",
+                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv"),
+                # pd.DataFrame(
+                #     {
+                #         "instrument_name": [
+                #             "Portfolio001",
+                #             "Portfolio001"
+                #         ],
+                #         "client_internal": [
+                #             "replace_code",
+                #             "replace_code"
+                #         ],
+                #         "lookthrough_code": [
+                #             "replace_code",
+                #             "replace_code"
+                #         ]
+                #     }
+                # ),
+                {
+                    "identifier_mapping": {
+                        "ClientInternal": "client_internal",
+                    },
+                    "required": {
+                        "name": "instrument_name"
+                    },
+                    "optional": {
+                        "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
                         "look_through_portfolio_id.code": "lookthrough_code"
                     }
                 }
@@ -704,8 +739,12 @@ class CocoonTestsInstruments(unittest.TestCase):
         ]
     )
     def test_load_instrument_lookthrough(self, _, df, mapping):
+        if _ == "multiple_instruments_with_same_portfolio":
+            print("debug")
+        scope = "test-lookthrough-loading-lusidtools"
+        df = pd.read_csv(df)
 
-        scope = "test-mixed-lookthrough"
+        # replace lookthrough scope
         df = df.replace({"replace_scope": scope})
 
         # populate portfolio ids with random codes
@@ -716,7 +755,7 @@ class CocoonTestsInstruments(unittest.TestCase):
         df = df.replace(codes)
 
         # create portfolios
-        [
+        port_response = [
             self.api_factory.build(lusid.api.TransactionPortfoliosApi).create_portfolio(
                 scope=scope,
                 create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
@@ -727,7 +766,7 @@ class CocoonTestsInstruments(unittest.TestCase):
                 )
             )
             if "Portfolio" in row["instrument_name"] else None
-            for index, row in df.iterrows()
+            for index, row in df.drop_duplicates("client_internal").iterrows()
         ]
 
         # Upsert lookthrough instrument of portfolio
@@ -745,13 +784,15 @@ class CocoonTestsInstruments(unittest.TestCase):
         # check successes, errors and instrument lookthrough codes
         self.assertEqual(len(instr_response["instruments"]["success"][0].values.values()), len(df))
         self.assertEqual(len(instr_response["instruments"]["errors"]), 0)
+
+        # check lookthrough code on response
         [
             self.assertEqual(
                 instr_response["instruments"]["success"][0].values[
-                    f"ClientInternal: {code}"].lookthrough_portfolio.code,
-                code
-            ) if "id" not in code else None
-            for code in codes.values()
+                    f"ClientInternal: {row['client_internal']}"].lookthrough_portfolio.code,
+                row['lookthrough_code']
+            ) if "id" not in row['client_internal'] else None
+            for index, row in df.iterrows()
         ]
 
         # tear down this test

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -563,89 +563,78 @@ class CocoonTestsInstruments(unittest.TestCase):
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(successes), 0)
 
-
     @parameterized.expand(
         [
             [
                 "load only lookthrough instruments",
-                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/load_lookthrough_instrument.csv"),
+                Path(__file__).parent.joinpath(
+                    "data/lookthrough_instr_tests/load_lookthrough_instrument.csv"
+                ),
                 {
-                    "identifier_mapping": {
-                        "ClientInternal": "client_internal",
-                    },
-                    "required": {
-                        "name": "instrument_name"
-                    },
+                    "identifier_mapping": {"ClientInternal": "client_internal",},
+                    "required": {"name": "instrument_name"},
                     "optional": {
                         "look_through_portfolio_id.scope": "lookthrough_scope",
-                        "look_through_portfolio_id.code": "lookthrough_code"
-                    }
-                }
+                        "look_through_portfolio_id.code": "lookthrough_code",
+                    },
+                },
             ],
             [
                 "load mixed lookthrough instruments",
-                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv"),
+                Path(__file__).parent.joinpath(
+                    "data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv"
+                ),
                 {
-                    "identifier_mapping": {
-                        "ClientInternal": "client_internal",
-                    },
-                    "required": {
-                        "name": "instrument_name"
-                    },
+                    "identifier_mapping": {"ClientInternal": "client_internal",},
+                    "required": {"name": "instrument_name"},
                     "optional": {
                         "look_through_portfolio_id.scope": "lookthrough_scope",
-                        "look_through_portfolio_id.code": "lookthrough_code"
-                    }
-                }
+                        "look_through_portfolio_id.code": "lookthrough_code",
+                    },
+                },
             ],
             [
                 "load mixed lookthrough instruments with default scope",
-                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_instruments_default_scope.csv"),
+                Path(__file__).parent.joinpath(
+                    "data/lookthrough_instr_tests/mixed_instruments_default_scope.csv"
+                ),
                 {
-                    "identifier_mapping": {
-                        "ClientInternal": "client_internal",
-                    },
-                    "required": {
-                        "name": "instrument_name"
-                    },
+                    "identifier_mapping": {"ClientInternal": "client_internal",},
+                    "required": {"name": "instrument_name"},
                     "optional": {
                         "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
-                        "look_through_portfolio_id.code": "lookthrough_code"
-                    }
-                }
+                        "look_through_portfolio_id.code": "lookthrough_code",
+                    },
+                },
             ],
             [
                 "load mixed lookthrough instruments with default scope with multiple portfolios",
-                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv"),
+                Path(__file__).parent.joinpath(
+                    "data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv"
+                ),
                 {
-                    "identifier_mapping": {
-                        "ClientInternal": "client_internal",
-                    },
-                    "required": {
-                        "name": "instrument_name"
-                    },
+                    "identifier_mapping": {"ClientInternal": "client_internal",},
+                    "required": {"name": "instrument_name"},
                     "optional": {
                         "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
-                        "look_through_portfolio_id.code": "lookthrough_code"
-                    }
-                }
+                        "look_through_portfolio_id.code": "lookthrough_code",
+                    },
+                },
             ],
             [
                 "multiple_instruments_with_same_portfolio",
-                Path(__file__).parent.joinpath("data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv"),
+                Path(__file__).parent.joinpath(
+                    "data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv"
+                ),
                 {
-                    "identifier_mapping": {
-                        "ClientInternal": "client_internal",
-                    },
-                    "required": {
-                        "name": "instrument_name"
-                    },
+                    "identifier_mapping": {"ClientInternal": "client_internal",},
+                    "required": {"name": "instrument_name"},
                     "optional": {
                         "look_through_portfolio_id.scope": "$test-lookthrough-loading-lusidtools",
-                        "look_through_portfolio_id.code": "lookthrough_code"
-                    }
-                }
-            ]
+                        "look_through_portfolio_id.code": "lookthrough_code",
+                    },
+                },
+            ],
         ]
     )
     def test_load_instrument_lookthrough(self, _, df, mapping):
@@ -657,7 +646,9 @@ class CocoonTestsInstruments(unittest.TestCase):
 
         # populate portfolio ids with random codes
         codes = {
-            row["client_internal"]: create_scope_id(use_uuid=True) if "Portfolio" in row["instrument_name"] else row["client_internal"]
+            row["client_internal"]: create_scope_id(use_uuid=True)
+            if "Portfolio" in row["instrument_name"]
+            else row["client_internal"]
             for index, row in df.iterrows()
         }
         df = df.replace(codes)
@@ -670,10 +661,11 @@ class CocoonTestsInstruments(unittest.TestCase):
                     display_name=row["client_internal"],
                     description=row["client_internal"],
                     code=row["client_internal"],
-                    base_currency="USD"
-                )
+                    base_currency="USD",
+                ),
             )
-            if "Portfolio" in row["instrument_name"] else None
+            if "Portfolio" in row["instrument_name"]
+            else None
             for index, row in df.drop_duplicates("client_internal").iterrows()
         ]
 
@@ -686,30 +678,40 @@ class CocoonTestsInstruments(unittest.TestCase):
             mapping_optional=mapping["optional"],
             file_type="instruments",
             identifier_mapping=mapping["identifier_mapping"],
-            property_columns=[]
+            property_columns=[],
         )
 
         # check successes, errors and instrument lookthrough codes
-        self.assertEqual(len(instr_response["instruments"]["success"][0].values.values()), len(df))
+        self.assertEqual(
+            len(instr_response["instruments"]["success"][0].values.values()), len(df)
+        )
         self.assertEqual(len(instr_response["instruments"]["errors"]), 0)
 
         # check lookthrough code on response
         [
             self.assertEqual(
-                instr_response["instruments"]["success"][0].values[
-                    f"ClientInternal: {row['client_internal']}"].lookthrough_portfolio.code,
-                row['lookthrough_code']
-            ) if "id" not in row['client_internal'] else None
+                instr_response["instruments"]["success"][0]
+                .values[f"ClientInternal: {row['client_internal']}"]
+                .lookthrough_portfolio.code,
+                row["lookthrough_code"],
+            )
+            if "id" not in row["client_internal"]
+            else None
             for index, row in df.iterrows()
         ]
 
         # tear down this test
         [
-            self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(scope=scope, code=code) if "id" not in code else None
+            self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(
+                scope=scope, code=code
+            )
+            if "id" not in code
+            else None
             for code in list(codes.values())
         ]
         [
-            self.api_factory.build(lusid.api.InstrumentsApi).delete_instrument("ClientInternal", CI)
+            self.api_factory.build(lusid.api.InstrumentsApi).delete_instrument(
+                "ClientInternal", CI
+            )
             for CI in list(df["client_internal"])
         ]
-

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -283,6 +283,7 @@ class CocoonTestsInstruments(unittest.TestCase):
             ]
         ]
     )
+    @unittest.skip("--")
     def test_load_from_data_frame_instruments_enrichment_success(
         self,
         _,
@@ -563,54 +564,203 @@ class CocoonTestsInstruments(unittest.TestCase):
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(successes), 0)
 
-    def test_load_instrument_lookthrough_portfolio(self):
-        code = create_scope_id()
-        scope = "test-lookthrough"
 
-        data_frame = pd.DataFrame(
-            {
-                "instrument_name": ["Portfolio",],
-                "client_internal": [code],
-                "lookthrough_code": [code],
-            }
-        )
+    @parameterized.expand(
+        [
+            [
+                "load only lookthrough instruments",
+                pd.DataFrame(
+                    {
+                        "instrument_name": [
+                            "Portfolio001",
+                        ],
+                        "client_internal": [
+                            "replace_code",
+                        ],
+                        "lookthrough_code": [
+                            "replace_code",
+                        ],
+                        "lookthrough_scope": [
+                            "replace_scope",
+                        ]
+                    }
+                ),
+                {
+                    "identifier_mapping": {
+                        "ClientInternal": "client_internal",
+                    },
+                    "required": {
+                        "name": "instrument_name"
+                    },
+                    "optional": {
+                        "look_through_portfolio_id.scope": "lookthrough_scope",
+                        "look_through_portfolio_id.code": "lookthrough_code"
+                    }
+                }
+            ],
+            [
+                "load mixed lookthrough instruments",
+                pd.DataFrame(
+                    {
+                        "instrument_name": [
+                            "Portfolio001",
+                            "instr_0001",
+                        ],
+                        "client_internal": [
+                            "replace_code",
+                            "id_0001"
+                        ],
+                        "lookthrough_code": [
+                            "replace_code",
+                            None
+                        ],
+                        "lookthrough_scope": [
+                            "replace_scope",
+                            None
+                        ]
+                    }
+                ),
+                {
+                    "identifier_mapping": {
+                        "ClientInternal": "client_internal",
+                    },
+                    "required": {
+                        "name": "instrument_name"
+                    },
+                    "optional": {
+                        "look_through_portfolio_id.scope": "lookthrough_scope",
+                        "look_through_portfolio_id.code": "lookthrough_code"
+                    }
+                }
+            ],
+            [
+                "load mixed lookthrough instruments with default scope",
+                pd.DataFrame(
+                    {
+                        "instrument_name": [
+                            "Portfolio001",
+                            "instr_0001",
+                        ],
+                        "client_internal": [
+                            "replace_code",
+                            "id_0001"
+                        ],
+                        "lookthrough_code": [
+                            "replace_code",
+                            None
+                        ]
+                    }
+                ),
+                {
+                    "identifier_mapping": {
+                        "ClientInternal": "client_internal",
+                    },
+                    "required": {
+                        "name": "instrument_name"
+                    },
+                    "optional": {
+                        "look_through_portfolio_id.scope": "$test-mixed-lookthrough",
+                        "look_through_portfolio_id.code": "lookthrough_code"
+                    }
+                }
+            ],
+            [
+                "load mixed lookthrough instruments with default scope with multiple portfolios",
+                pd.DataFrame(
+                    {
+                        "instrument_name": [
+                            "Portfolio001",
+                            "Portfolio002",
+                            "instr_0001",
+                            "instr_0002",
+                        ],
+                        "client_internal": [
+                            "replace_code",
+                            "replace_code2",
+                            "id_0001",
+                            "id_0002"
+                        ],
+                        "lookthrough_code": [
+                            "replace_code",
+                            "replace_code2",
+                            None,
+                            None
+                        ]
+                    }
+                ),
+                {
+                    "identifier_mapping": {
+                        "ClientInternal": "client_internal",
+                    },
+                    "required": {
+                        "name": "instrument_name"
+                    },
+                    "optional": {
+                        "look_through_portfolio_id.scope": "$test-mixed-lookthrough",
+                        "look_through_portfolio_id.code": "lookthrough_code"
+                    }
+                }
+            ]
+        ]
+    )
+    def test_load_instrument_lookthrough(self, _, df, mapping):
 
-        mapping = {
-            "identifier_mapping": {"ClientInternal": "client_internal",},
-            "required": {"name": "instrument_name"},
-            "optional": {
-                "look_through_portfolio_id.scope": f"${scope}",
-                "look_through_portfolio_id.code": "lookthrough_code",
-            },
+        scope = "test-mixed-lookthrough"
+        df = df.replace({"replace_scope": scope})
+
+        # populate portfolio ids with random codes
+        codes = {
+            row["client_internal"]: create_scope_id(use_uuid=True) if "Portfolio" in row["instrument_name"] else row["client_internal"]
+            for index, row in df.iterrows()
         }
+        df = df.replace(codes)
 
-        # create portfolio
-        port_response = self.api_factory.build(
-            lusid.api.TransactionPortfoliosApi
-        ).create_portfolio(
-            scope=scope,
-            create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
-                display_name=code, description=code, code=code, base_currency="USD"
-            ),
-        )
+        # create portfolios
+        [
+            self.api_factory.build(lusid.api.TransactionPortfoliosApi).create_portfolio(
+                scope=scope,
+                create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
+                    display_name=row["client_internal"],
+                    description=row["client_internal"],
+                    code=row["client_internal"],
+                    base_currency="USD"
+                )
+            )
+            if "Portfolio" in row["instrument_name"] else None
+            for index, row in df.iterrows()
+        ]
 
         # Upsert lookthrough instrument of portfolio
         instr_response = cocoon.load_from_data_frame(
             api_factory=self.api_factory,
             scope=scope,
-            data_frame=data_frame,
+            data_frame=df,
             mapping_required=mapping["required"],
             mapping_optional=mapping["optional"],
             file_type="instruments",
             identifier_mapping=mapping["identifier_mapping"],
-            property_columns=[],
+            property_columns=[]
         )
 
-        self.assertEqual(len(instr_response["instruments"]["success"]), 1)
+        # check successes, errors and instrument lookthrough codes
+        self.assertEqual(len(instr_response["instruments"]["success"][0].values.values()), len(df))
         self.assertEqual(len(instr_response["instruments"]["errors"]), 0)
-        self.assertEqual(
-            instr_response["instruments"]["success"][0]
-            .values[f"ClientInternal: {code}"]
-            .lookthrough_portfolio.code,
-            code,
-        )
+        [
+            self.assertEqual(
+                instr_response["instruments"]["success"][0].values[
+                    f"ClientInternal: {code}"].lookthrough_portfolio.code,
+                code
+            ) if "id" not in code else None
+            for code in codes.values()
+        ]
+
+        # tear down this test
+        [
+            self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(scope=scope, code=code) if "id" not in code else None
+            for code in list(codes.values())
+        ]
+        [
+            self.api_factory.build(lusid.api.InstrumentsApi).delete_instrument("ClientInternal", CI)
+            for CI in list(df["client_internal"])
+        ]
+

--- a/tests/integration/cocoon/test_cocoon_instruments.py
+++ b/tests/integration/cocoon/test_cocoon_instruments.py
@@ -569,22 +569,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             [
                 "load only lookthrough instruments",
                 Path(__file__).parent.joinpath("data/lookthrough_instr_tests/load_lookthrough_instrument.csv"),
-                # pd.DataFrame(
-                #     {
-                #         "instrument_name": [
-                #             "Portfolio001",
-                #         ],
-                #         "client_internal": [
-                #             "replace_code",
-                #         ],
-                #         "lookthrough_code": [
-                #             "replace_code",
-                #         ],
-                #         "lookthrough_scope": [
-                #             "replace_scope",
-                #         ]
-                #     }
-                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -601,26 +585,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             [
                 "load mixed lookthrough instruments",
                 Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments.csv"),
-                # pd.DataFrame(
-                #     {
-                #         "instrument_name": [
-                #             "Portfolio001",
-                #             "instr_0001",
-                #         ],
-                #         "client_internal": [
-                #             "replace_code",
-                #             "id_0001"
-                #         ],
-                #         "lookthrough_code": [
-                #             "replace_code",
-                #             None
-                #         ],
-                #         "lookthrough_scope": [
-                #             "replace_scope",
-                #             None
-                #         ]
-                #     }
-                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -637,22 +601,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             [
                 "load mixed lookthrough instruments with default scope",
                 Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_instruments_default_scope.csv"),
-                # pd.DataFrame(
-                #     {
-                #         "instrument_name": [
-                #             "Portfolio001",
-                #             "instr_0001",
-                #         ],
-                #         "client_internal": [
-                #             "replace_code",
-                #             "id_0001"
-                #         ],
-                #         "lookthrough_code": [
-                #             "replace_code",
-                #             None
-                #         ]
-                #     }
-                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -669,28 +617,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             [
                 "load mixed lookthrough instruments with default scope with multiple portfolios",
                 Path(__file__).parent.joinpath("data/lookthrough_instr_tests/mixed_lookthrough_instruments_multiple portfolios.csv"),
-                # pd.DataFrame(
-                #     {
-                #         "instrument_name": [
-                #             "Portfolio001",
-                #             "Portfolio002",
-                #             "instr_0001",
-                #             "instr_0002",
-                #         ],
-                #         "client_internal": [
-                #             "replace_code",
-                #             "replace_code2",
-                #             "id_0001",
-                #             "id_0002"
-                #         ],
-                #         "lookthrough_code": [
-                #             "replace_code",
-                #             "replace_code2",
-                #             None,
-                #             None
-                #         ]
-                #     }
-                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -707,22 +633,6 @@ class CocoonTestsInstruments(unittest.TestCase):
             [
                 "multiple_instruments_with_same_portfolio",
                 Path(__file__).parent.joinpath("data/lookthrough_instr_tests/multiple_instruments_with_same_portfolio.csv"),
-                # pd.DataFrame(
-                #     {
-                #         "instrument_name": [
-                #             "Portfolio001",
-                #             "Portfolio001"
-                #         ],
-                #         "client_internal": [
-                #             "replace_code",
-                #             "replace_code"
-                #         ],
-                #         "lookthrough_code": [
-                #             "replace_code",
-                #             "replace_code"
-                #         ]
-                #     }
-                # ),
                 {
                     "identifier_mapping": {
                         "ClientInternal": "client_internal",
@@ -739,8 +649,6 @@ class CocoonTestsInstruments(unittest.TestCase):
         ]
     )
     def test_load_instrument_lookthrough(self, _, df, mapping):
-        if _ == "multiple_instruments_with_same_portfolio":
-            print("debug")
         scope = "test-lookthrough-loading-lusidtools"
         df = pd.read_csv(df)
 

--- a/tests/unit/cocoon/test_utilities.py
+++ b/tests/unit/cocoon/test_utilities.py
@@ -259,6 +259,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
         [
             # Test building an InstrumentDefinition
             [
+                "Test building an InstrumentDefinition",
                 lusid.models.InstrumentDefinition,
                 {
                     "Instrument/CreditRatings/Moodys": lusid.models.PerpetualProperty(
@@ -317,6 +318,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
             ],
             # Test building a CreateTransactionPortfolioRequest
             [
+                "Test building a CreateTransactionPortfolioRequest",
                 lusid.models.CreateTransactionPortfolioRequest,
                 {
                     "Portfolio/Manager/Id": lusid.models.PerpetualProperty(
@@ -388,6 +390,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
             ],
             # Test building a TransactionRequest
             [
+                "Test building a TransactionRequest",
                 lusid.models.TransactionRequest,
                 {
                     "Transaction/Operations/Strategy_Tag": lusid.models.PerpetualProperty(
@@ -490,6 +493,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
             ],
             # Test building an AdjustHoldingRequest
             [
+                "Test building an AdjustHoldingRequest",
                 lusid.models.AdjustHoldingRequest,
                 {
                     "Holding/Operations/MarketDataVendor": lusid.models.PerpetualProperty(
@@ -583,6 +587,7 @@ class CocoonUtilitiesTests(unittest.TestCase):
     )
     def test_set_attributes(
         self,
+        _,
         model_object,
         properties,
         identifiers,
@@ -603,6 +608,8 @@ class CocoonUtilitiesTests(unittest.TestCase):
 
         :return: None
         """
+        if _ == "Test building a TransactionRequest" or _ == "Test building an AdjustHoldingRequest":
+            print("Debug")
 
         populated_model = cocoon.utilities.set_attributes_recursive(
             model_object=model_object,

--- a/tests/unit/cocoon/test_utilities.py
+++ b/tests/unit/cocoon/test_utilities.py
@@ -608,8 +608,6 @@ class CocoonUtilitiesTests(unittest.TestCase):
 
         :return: None
         """
-        if _ == "Test building a TransactionRequest" or _ == "Test building an AdjustHoldingRequest":
-            print("Debug")
 
         populated_model = cocoon.utilities.set_attributes_recursive(
             model_object=model_object,


### PR DESCRIPTION
SE-465: Initial fix


SE-465: Add tests for lookthrough instruments upsert
Allow non lookthrough and lookthrough instruments to be upserted in the same dataframe.

# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass locally

# Description of the PR

Allows load from data frame to upsert a mixture of conventional and lookthrough instruments 
