### PR TITLE
Add timeout of 30 mins to cron

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   cron-build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

The job should timeout if tests take more than 30 mins