### PR TITLE
SE-610: Adding support for bond instrument in load_from_data_frame

### DIFF
--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -269,7 +269,8 @@ def set_attributes_recursive(
             if (key, attribute_type) == ("identifiers", "dict(str, str)"):
                 obj_init_values[key] = {
                     str_key: row[str_value]
-                    for str_key, str_value in mapping[key].items() if not pd.isna(row[str_value])
+                    for str_key, str_value in mapping[key].items()
+                    if not pd.isna(row[str_value])
                 }
             else:
                 obj_init_values[key] = additional_attributes[key]
@@ -290,7 +291,9 @@ def set_attributes_recursive(
                 if "date" in key or "created" in key or "effective_at" in key:
                     obj_init_values[key] = str(DateOrCutLabel(row[mapping[key]]))
                 # Converts to a list element if it is a list field
-                elif 'list' in attribute_type and not isinstance(row[mapping[key]], list):
+                elif "list" in attribute_type and not isinstance(
+                    row[mapping[key]], list
+                ):
                     obj_init_values[key] = [row[mapping[key]]]
                 else:
                     obj_init_values[key] = row[mapping[key]]
@@ -315,7 +318,6 @@ def set_attributes_recursive(
 
             obj_init_values[key] = [value] if nested_type == "list" else value
 
-
     """
     If all attributes are None propagate None rather than a model filled with Nones. For example if a CorporateActionSourceId
     has no scope or code return build a model with CorporateActionSourceId = None rather than CorporateActionSourceId = 
@@ -327,7 +329,7 @@ def set_attributes_recursive(
 
     # Create an instance of and populate the model object
     instance = model_object(**obj_init_values)
-    
+
     # Support for polymorphism, we can identify these `abstract` classes by the existence of the below
     if getattr(instance, "discriminator"):
         discriminator = getattr(instance, getattr(instance, "discriminator"))
@@ -335,9 +337,7 @@ def set_attributes_recursive(
         actual_class = model_object.discriminator_value_class_map[discriminator]
 
         return set_attributes_recursive(
-            model_object=getattr(lusid.models, actual_class),
-            mapping=mapping,
-            row=row,
+            model_object=getattr(lusid.models, actual_class), mapping=mapping, row=row,
         )
 
     return instance

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -260,9 +260,20 @@ def set_attributes_recursive(
     # For each of the attributes to populate
     for key in list(populate_attributes):
 
+        # Get the attribute type
+        attribute_type = obj_attr[key]
+
         # If it is an additional attribute, populate it with the provided values and move to the next attribute
         if key in list(additional_attributes.keys()):
-            obj_init_values[key] = additional_attributes[key]
+            # Handle identifiers provided within instrument definition (e.g. 'Bond', 'Future', etc.)
+            if (key, attribute_type) == ("identifiers", "dict(str, str)"):
+                obj_init_values[key] = {
+                    str_key: row[str_value]
+                    for str_key, str_value in mapping[key].items() if not pd.isna(row[str_value])
+                }
+            else:
+                obj_init_values[key] = additional_attributes[key]
+
             continue
 
         # This block keeps track of the number of missing (non-additional) attributes
@@ -271,9 +282,6 @@ def set_attributes_recursive(
             if mapping[key] is None:
                 none_count += 1
 
-        # Get the attribute type
-        attribute_type = obj_attr[key]
-
         # If this is the last object and there is no more nesting set the value from the row
         if not isinstance(mapping[key], dict):
             # If this exists in the mapping with a value and there is a value in the row for it
@@ -281,6 +289,9 @@ def set_attributes_recursive(
                 # Converts to a date if it is a date field
                 if "date" in key or "created" in key or "effective_at" in key:
                     obj_init_values[key] = str(DateOrCutLabel(row[mapping[key]]))
+                # Converts to a list element if it is a list field
+                elif 'list' in attribute_type and not isinstance(row[mapping[key]], list):
+                    obj_init_values[key] = [row[mapping[key]]]
                 else:
                     obj_init_values[key] = row[mapping[key]]
             elif obj_attr_required_map[key] == "required":
@@ -304,6 +315,7 @@ def set_attributes_recursive(
 
             obj_init_values[key] = [value] if nested_type == "list" else value
 
+
     """
     If all attributes are None propagate None rather than a model filled with Nones. For example if a CorporateActionSourceId
     has no scope or code return build a model with CorporateActionSourceId = None rather than CorporateActionSourceId = 
@@ -314,7 +326,21 @@ def set_attributes_recursive(
         return None
 
     # Create an instance of and populate the model object
-    return model_object(**obj_init_values)
+    instance = model_object(**obj_init_values)
+    
+    # Support for polymorphism, we can identify these `abstract` classes by the existence of the below
+    if getattr(instance, "discriminator"):
+        discriminator = getattr(instance, getattr(instance, "discriminator"))
+
+        actual_class = model_object.discriminator_value_class_map[discriminator]
+
+        return set_attributes_recursive(
+            model_object=getattr(lusid.models, actual_class),
+            mapping=mapping,
+            row=row,
+        )
+
+    return instance
 
 
 @checkargs
@@ -795,7 +821,6 @@ def handle_nested_default_and_column_mapping(
     This function handles when a mapping is provided which contains as a value a dictionary with a column and/or default
     key rather than just a string with the column name. It populates the DataFrame with the default value as appropriate
     and removes the nesting so that the model can be populated later.
-
     Parameters
     ----------
     data_frame : pd.DataFrame
@@ -804,7 +829,6 @@ def handle_nested_default_and_column_mapping(
         The original mapping (can be required or optional)
     constant_prefix : str
         The prefix that can be used to specify a constant
-
     Returns
     -------
     dataframe : pd.DataFrame

--- a/tests/unit/cocoon/data/global-fund-fixed-income-master.csv
+++ b/tests/unit/cocoon/data/global-fund-fixed-income-master.csv
@@ -1,0 +1,5 @@
+Name,ISIN,Client Internal,Issue Date,Maturity Date,Currency,Payment Frequency,Day Count Convention,Roll Convention,Payment Calendars,Reset Calendars,Settlement Days,Reset Days,Principal,Coupon,Instrument Type
+DISNEY 7 2032,US25468PBW59,imd_34534538,28/02/2002,01/03/2032,USD,6M,Thirty360,MF,US,US,2,2,500000000,0.07,Bond
+IBM 7 2025,US459200AM34,imd_34534539,10/30/1995,30/10/2025,USD,6M,Thirty360,MF,US,US,2,2,600000000,0.07,Bond
+USTreasury 6.875 2025,US912810EV62,imd_34534540,15/08/1995,13/08/2025,USD,6M,ActAct,MF,US,US,2,2,128000000,0.06875,Bond
+USTreasury 0.875 2030,US91282CAV37,imd_34534541,13/08/2018,15/11/2030,USD,6M,ActAct,MF,US,US,2,2,372000000,0.00875,Bond

--- a/tests/unit/cocoon/test_cocoon_complex_instrument.py
+++ b/tests/unit/cocoon/test_cocoon_complex_instrument.py
@@ -40,7 +40,7 @@ class ComplexInstrumentTests(unittest.TestCase):
             "definition.flow_conventions.payment_calendars": "Payment Calendars",
             "definition.flow_conventions.reset_calendars": "Reset Calendars",
             "definition.flow_conventions.settle_days": "Settlement Days",
-            "definition.flow_conventions.reset_days": "Reset Days"
+            "definition.flow_conventions.reset_days": "Reset Days",
         }
         cls.mapping_optional = {}
         cls.identifier_mapping = {"Isin": "ISIN", "ClientInternal": "Client Internal"}
@@ -69,20 +69,22 @@ class ComplexInstrumentTests(unittest.TestCase):
                 settle_days=2,
                 reset_days=2,
             ),
-            identifiers={'clientInternal': 'imd_34534538'},
-            instrument_type="Bond"
+            identifiers={"clientInternal": "imd_34534538"},
+            instrument_type="Bond",
         )
 
-        instrument_request = {"ClientInternal: imd_34534538": models.InstrumentDefinition(
-            # instrument display name
-            name="DISNEY_7_2032",
-            # unique instrument identifier
-            identifiers={
-                "ClientInternal": models.InstrumentIdValue("imd_34534538"),
-                "Isin": models.InstrumentIdValue("US25468PBW59")},
-            # instrument definition
-            definition=instrument_definition
-        )
+        instrument_request = {
+            "ClientInternal: imd_34534538": models.InstrumentDefinition(
+                # instrument display name
+                name="DISNEY_7_2032",
+                # unique instrument identifier
+                identifiers={
+                    "ClientInternal": models.InstrumentIdValue("imd_34534538"),
+                    "Isin": models.InstrumentIdValue("US25468PBW59"),
+                },
+                # instrument definition
+                definition=instrument_definition,
+            )
         }
 
         return self.instruments_api.upsert_instruments(instrument_request)
@@ -154,7 +156,10 @@ class ComplexInstrumentTests(unittest.TestCase):
         # Check instrument definition in response matches expected outcome
         for key in expected_outcome.values.keys():
             response_obj = combined_successes[key]
-            self.assertEqual(response_obj.instrument_definition, expected_outcome.values[key].instrument_definition)
+            self.assertEqual(
+                response_obj.instrument_definition,
+                expected_outcome.values[key].instrument_definition,
+            )
 
     def test_load_from_dataframe_with_unsupported_inst_type(self) -> None:
         """
@@ -181,7 +186,7 @@ class ComplexInstrumentTests(unittest.TestCase):
         # Load data frame with instrument data
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
         # Overwrite "Instrument Type" to an unsupported value
-        data_frame["Instrument Type"].replace('Bond', 'Foo', inplace=True)
+        data_frame["Instrument Type"].replace("Bond", "Foo", inplace=True)
 
         # Check that ValueError is raised
         with self.assertRaises(ValueError):
@@ -197,5 +202,5 @@ class ComplexInstrumentTests(unittest.TestCase):
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/cocoon/test_cocoon_complex_instrument.py
+++ b/tests/unit/cocoon/test_cocoon_complex_instrument.py
@@ -1,0 +1,201 @@
+import unittest
+from pathlib import Path
+import pandas as pd
+
+from lusidtools import cocoon as cocoon
+from parameterized import parameterized
+import lusid
+import lusid.models as models
+from lusid.utilities import ApiClientFactory
+from lusidtools import logger
+from datetime import datetime
+import pytz
+
+
+class ComplexInstrumentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
+        cls.api_factory = lusid.utilities.ApiClientFactory(
+            api_secrets_filename=secrets_file
+        )
+        cls.logger = logger.LusidLogger("debug")
+        cls.instruments_api = cls.api_factory.build(lusid.api.InstrumentsApi)
+
+        # Set test parameters as class methods
+        cls.scope = "TestScope"
+        cls.mapping_required = {
+            "name": "Name",
+            "definition.start_date": "Issue Date",
+            "definition.maturity_date": "Maturity Date",
+            "definition.dom_ccy": "Currency",
+            "definition.instrument_type": "Instrument Type",
+            "definition.principal": "Principal",
+            "definition.coupon_rate": "Coupon",
+            "definition.identifiers.ClientInternal": "Client Internal",
+            "definition.flow_conventions.currency": "Currency",
+            "definition.flow_conventions.payment_frequency": "Payment Frequency",
+            "definition.flow_conventions.day_count_convention": "Day Count Convention",
+            "definition.flow_conventions.roll_convention": "Roll Convention",
+            "definition.flow_conventions.payment_calendars": "Payment Calendars",
+            "definition.flow_conventions.reset_calendars": "Reset Calendars",
+            "definition.flow_conventions.settle_days": "Settlement Days",
+            "definition.flow_conventions.reset_days": "Reset Days"
+        }
+        cls.mapping_optional = {}
+        cls.identifier_mapping = {"Isin": "ISIN", "ClientInternal": "Client Internal"}
+        cls.file_name = "data/global-fund-fixed-income-master.csv"
+
+    # Set the expected result object using LUSID sdk
+    def expected_response(self):
+        instrument_definition = models.Bond(
+            start_date=datetime(2002, 2, 28, tzinfo=pytz.utc),
+            maturity_date=datetime(2032, 3, 1, tzinfo=pytz.utc),
+            dom_ccy="USD",
+            coupon_rate=0.07,
+            principal=500000000,
+            flow_conventions=models.FlowConventions(
+                # coupon payment currency
+                currency="USD",
+                # semi-annual coupon payments
+                payment_frequency="6M",
+                # using an Actual/365 day count convention (other options : Act360, ActAct, ...
+                day_count_convention="Thirty360",
+                # modified following rolling convention (other options : ModifiedPrevious, NoAdjustment, EndOfMonth,...)
+                roll_convention="MF",
+                # no holiday calendar supplied
+                payment_calendars=["US"],
+                reset_calendars=["US"],
+                settle_days=2,
+                reset_days=2,
+            ),
+            identifiers={'clientInternal': 'imd_34534538'},
+            instrument_type="Bond"
+        )
+
+        instrument_request = {"ClientInternal: imd_34534538": models.InstrumentDefinition(
+            # instrument display name
+            name="DISNEY_7_2032",
+            # unique instrument identifier
+            identifiers={
+                "ClientInternal": models.InstrumentIdValue("imd_34534538"),
+                "Isin": models.InstrumentIdValue("US25468PBW59")},
+            # instrument definition
+            definition=instrument_definition
+        )
+        }
+
+        return self.instruments_api.upsert_instruments(instrument_request)
+
+    def test_load_from_dataframe_bond(self) -> None:
+        """
+            Test that instruments can be loaded successfully using load_from_data_frame()
+
+            :param str scope: The scope of the portfolios to load the transactions into
+            :param str file_name: The name of the test data file
+            :param dict{str, str} mapping_required: The dictionary mapping the dataframe fields to LUSID's required base transaction/holding schema
+            :param dict{str, str} mapping_optional: The dictionary mapping the dataframe fields to LUSID's optional base transaction/holding schema
+            :param dict{str, str} identifier_mapping: The dictionary mapping of LUSID instrument identifiers to identifiers in the dataframe
+            :param list[str] property_columns: The columns to create properties for
+            :param str properties_scope: The scope to add the properties to
+
+            :return: None
+            """
+        # Load parameters
+        scope = self.scope
+        mapping_required = self.mapping_required
+        mapping_optional = self.mapping_optional
+        identifier_mapping = self.identifier_mapping
+        file_name = self.file_name
+        # Load expected outcome for an instrument
+        expected_outcome = self.expected_response()
+
+        # Load data frame with instrument data
+        data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
+
+        responses = cocoon.cocoon.load_from_data_frame(
+            api_factory=self.api_factory,
+            scope=scope,
+            data_frame=data_frame,
+            mapping_required=mapping_required,
+            mapping_optional=mapping_optional,
+            file_type="instruments",
+            identifier_mapping=identifier_mapping,
+            instrument_name_enrichment=True,
+        )
+
+        self.assertEqual(
+            first=sum(
+                [
+                    len(response.values)
+                    for response in responses["instruments"]["success"]
+                ]
+            ),
+            second=len(data_frame["Client Internal"].unique()),
+        )
+
+        self.assertEqual(
+            first=sum(
+                [
+                    len(response.failed)
+                    for response in responses["instruments"]["success"]
+                ]
+            ),
+            second=0,
+        )
+
+        # Clean and aggregate successful responses into a dictionary
+        combined_successes = {
+            correlation_id: instrument
+            for response in responses["instruments"]["success"]
+            for correlation_id, instrument in response.values.items()
+        }
+
+        # Check instrument definition in response matches expected outcome
+        for key in expected_outcome.values.keys():
+            response_obj = combined_successes[key]
+            self.assertEqual(response_obj.instrument_definition, expected_outcome.values[key].instrument_definition)
+
+    def test_load_from_dataframe_with_unsupported_inst_type(self) -> None:
+        """
+            Tests that an invalid instrument_type raises a ValueError in load_from_data_frame()
+
+            :param str scope: The scope of the portfolios to load the transactions into
+            :param str file_name: The name of the test data file
+            :param dict{str, str} mapping_required: The dictionary mapping the dataframe fields to LUSID's required base transaction/holding schema
+            :param dict{str, str} mapping_optional: The dictionary mapping the dataframe fields to LUSID's optional base transaction/holding schema
+            :param dict{str, str} identifier_mapping: The dictionary mapping of LUSID instrument identifiers to identifiers in the dataframe
+            :param list[str] property_columns: The columns to create properties for
+            :param str properties_scope: The scope to add the properties to
+
+            :return: None
+            """
+
+        # Load parameters
+        scope = self.scope
+        mapping_required = self.mapping_required
+        mapping_optional = self.mapping_optional
+        identifier_mapping = self.identifier_mapping
+        file_name = self.file_name
+
+        # Load data frame with instrument data
+        data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
+        # Overwrite "Instrument Type" to an unsupported value
+        data_frame["Instrument Type"].replace('Bond', 'Foo', inplace=True)
+
+        # Check that ValueError is raised
+        with self.assertRaises(ValueError):
+            cocoon.cocoon.load_from_data_frame(
+                api_factory=self.api_factory,
+                scope=scope,
+                data_frame=data_frame,
+                mapping_required=mapping_required,
+                mapping_optional=mapping_optional,
+                file_type="instruments",
+                identifier_mapping=identifier_mapping,
+                instrument_name_enrichment=True,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
SE-610: Adding support complex instruments in load_from_data_frame

# Pull Request Checklist

- [ x ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ x ] Tests pass

# Description of the PR

- Added support for Bond Instrument definition to ```load_from_data_frame```
- Tests passed
