### PR TITLE
SE-1201: Added flag for extended errors in cocoon printer

### DIFF
--- a/lusidtools/cocoon/cocoon_printer.py
+++ b/lusidtools/cocoon/cocoon_printer.py
@@ -34,7 +34,9 @@ def check_dict_for_required_keys(
             )
 
 
-def get_errors_from_response(list_of_API_exceptions: list, extended_error_details: bool = False):
+def get_errors_from_response(
+    list_of_API_exceptions: list, extended_error_details: bool = False
+):
     """
     This function gets the status code and reason from API exception
 
@@ -66,7 +68,9 @@ def get_errors_from_response(list_of_API_exceptions: list, extended_error_detail
     column_names = ["error_items", "status"]
 
     if extended_error_details:
-        request_id = [item.headers.get("lusid-meta-requestId") for item in list_of_API_exceptions]
+        request_id = [
+            item.headers.get("lusid-meta-requestId") for item in list_of_API_exceptions
+        ]
         error_body = [item.body for item in list_of_API_exceptions]
         items_list.extend([request_id, error_body])
         column_names.extend(["request_id", "error_body"])
@@ -136,8 +140,7 @@ def get_non_href_response(response: dict, file_type: str, data_entity_details=Fa
 
 
 def format_instruments_response(
-    response: dict,
-    extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from instrument requests and returns successful, failed and errored statuses for
@@ -175,8 +178,7 @@ def format_instruments_response(
 
 
 def format_portfolios_response(
-        response: dict,
-        extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from portfolio requests and returns successful and errored statuses for
@@ -204,14 +206,15 @@ def format_portfolios_response(
     # get success
     items_success = [batch.id.code for batch in response[file_type]["success"]]
 
-    errors = get_errors_from_response(response[file_type]["errors"], extended_error_details)
+    errors = get_errors_from_response(
+        response[file_type]["errors"], extended_error_details
+    )
 
     return (pd.DataFrame(items_success, columns=["successful items"]), errors)
 
 
 def format_transactions_response(
-        response: dict,
-        extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from transaction requests and returns successful and errored statuses for
@@ -241,7 +244,9 @@ def format_transactions_response(
     # get success
     items_success = [batch.href for batch in response[file_type]["success"]]
 
-    errors = get_errors_from_response(response[file_type]["errors"], extended_error_details)
+    errors = get_errors_from_response(
+        response[file_type]["errors"], extended_error_details
+    )
 
     return (
         pd.DataFrame(
@@ -253,8 +258,7 @@ def format_transactions_response(
 
 
 def format_holdings_response(
-        response: dict,
-        extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from holding requests and returns successful and errored statuses for
@@ -284,7 +288,9 @@ def format_holdings_response(
     # get success
     items_success = [batch.href for batch in response[file_type]["success"]]
 
-    errors = get_errors_from_response(response[file_type]["errors"], extended_error_details)
+    errors = get_errors_from_response(
+        response[file_type]["errors"], extended_error_details
+    )
 
     return (
         pd.DataFrame(
@@ -296,8 +302,7 @@ def format_holdings_response(
 
 
 def format_quotes_response(
-    response: dict,
-    extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from quotes requests and returns successful, failed and errored statuses for
@@ -337,8 +342,7 @@ def format_quotes_response(
 
 
 def format_reference_portfolios_response(
-    response: dict,
-    extended_error_details: bool = False,
+    response: dict, extended_error_details: bool = False,
 ) -> (pd.DataFrame, pd.DataFrame):
     """
     This function unpacks a response from reference portfolio requests and returns successful and errored statuses for request constituents.
@@ -366,6 +370,8 @@ def format_reference_portfolios_response(
     # get success
     items_success = [batch.id.code for batch in response[file_type]["success"]]
 
-    errors = get_errors_from_response(response[file_type]["errors"], extended_error_details)
+    errors = get_errors_from_response(
+        response[file_type]["errors"], extended_error_details
+    )
 
     return (pd.DataFrame(items_success, columns=["successful items"]), errors)

--- a/tests/integration/cocoon/data/cocoon_format_portfolio_errors.csv
+++ b/tests/integration/cocoon/data/cocoon_format_portfolio_errors.csv
@@ -1,0 +1,4 @@
+,FundCode,display_name,created,base_currency,description
+0,Portfolio-1,Portfolio-1,2020-10-09T08:00:00Z,GBP,Portfolio-1
+1,Portfolio-2,Portfolio-2,2020-10-09T08:00:00Z,GBP,Portfolio-2
+3,Portfolio-3,Portfolio-3,2020-10-09T08:00:00Z,MAR,Portfolio-3

--- a/tests/integration/cocoon/test_cocoon_printer.py
+++ b/tests/integration/cocoon/test_cocoon_printer.py
@@ -24,23 +24,27 @@ class CocoonPrinterIntegrationTests(unittest.TestCase):
         Test that the cocoon printer also returns the RequestID and ErrorDetails for any errors in the response.
         """
         # Load a portfolio that will contain an error using load_from_data_frame
-        data_frame = pd.read_csv(Path(__file__).parent.joinpath("data/cocoon_format_portfolio_errors.csv"))
+        data_frame = pd.read_csv(
+            Path(__file__).parent.joinpath("data/cocoon_format_portfolio_errors.csv")
+        )
         portfolio_response = load_from_data_frame(
             api_factory=self.api_factory,
             scope="cocoon_format_errors",
             data_frame=data_frame,
             mapping_required={
-                    "code": "FundCode",
-                    "display_name": "display_name",
-                    "created": "created",
-                    "base_currency": "base_currency",
-                },
+                "code": "FundCode",
+                "display_name": "display_name",
+                "created": "created",
+                "base_currency": "base_currency",
+            },
             mapping_optional={"description": "description", "accounting_method": None},
-            file_type="portfolios"
+            file_type="portfolios",
         )
 
         # Pass the response into the cocoon printer formatter
-        succ, err = format_portfolios_response(portfolio_response, extended_error_details=True)
+        succ, err = format_portfolios_response(
+            portfolio_response, extended_error_details=True
+        )
 
         # Assert that the error part includes RequestID details and ErrorDetails
         self.assertEqual(2, len(succ))
@@ -50,7 +54,9 @@ class CocoonPrinterIntegrationTests(unittest.TestCase):
             # Regex for request id patterns
             self.assertRegex(row[err.columns[2]], r"[A-Z0-9]{13}:[0-9]{8}")
             # Deserialise the ErrorDetails field and check one of the values
-            self.assertEqual(json.loads(row[err.columns[3]]).get("name"), "UndefinedCurrencyFailure")
+            self.assertEqual(
+                json.loads(row[err.columns[3]]).get("name"), "UndefinedCurrencyFailure"
+            )
 
         # Delete the portfolios at the end of the test
         for portfolio in portfolio_response.get("portfolios").get("success"):
@@ -59,5 +65,5 @@ class CocoonPrinterIntegrationTests(unittest.TestCase):
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/cocoon/test_cocoon_printer.py
+++ b/tests/integration/cocoon/test_cocoon_printer.py
@@ -1,0 +1,63 @@
+import unittest
+import json
+from pathlib import Path
+import pandas as pd
+import lusid
+from lusidtools import logger
+from lusidtools.cocoon.cocoon import load_from_data_frame
+from lusidtools.cocoon.cocoon_printer import format_portfolios_response
+from lusidfeature import lusid_feature
+
+
+class CocoonPrinterIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
+        cls.api_factory = lusid.utilities.ApiClientFactory(
+            api_secrets_filename=secrets_file
+        )
+        cls.logger = logger.LusidLogger("debug")
+
+    @lusid_feature("T6-1")
+    def test_format_portfolios_response_includes_extended_errors(self):
+        """
+        Test that the cocoon printer also returns the RequestID and ErrorDetails for any errors in the response.
+        """
+        # Load a portfolio that will contain an error using load_from_data_frame
+        data_frame = pd.read_csv(Path(__file__).parent.joinpath("data/cocoon_format_portfolio_errors.csv"))
+        portfolio_response = load_from_data_frame(
+            api_factory=self.api_factory,
+            scope="cocoon_format_errors",
+            data_frame=data_frame,
+            mapping_required={
+                    "code": "FundCode",
+                    "display_name": "display_name",
+                    "created": "created",
+                    "base_currency": "base_currency",
+                },
+            mapping_optional={"description": "description", "accounting_method": None},
+            file_type="portfolios"
+        )
+
+        # Pass the response into the cocoon printer formatter
+        succ, err = format_portfolios_response(portfolio_response, extended_error_details=True)
+
+        # Assert that the error part includes RequestID details and ErrorDetails
+        self.assertEqual(2, len(succ))
+        self.assertEqual(1, len(err))
+        for index, row in err.iterrows():
+            self.assertEqual(row[err.columns[0]], "Bad Request")
+            # Regex for request id patterns
+            self.assertRegex(row[err.columns[2]], r"[A-Z0-9]{13}:[0-9]{8}")
+            # Deserialise the ErrorDetails field and check one of the values
+            self.assertEqual(json.loads(row[err.columns[3]]).get("name"), "UndefinedCurrencyFailure")
+
+        # Delete the portfolios at the end of the test
+        for portfolio in portfolio_response.get("portfolios").get("success"):
+            self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(
+                scope="cocoon_format_errors", code=portfolio.id.code
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -189,7 +189,10 @@ responses_no_success_field = {
     "reference_portfolios": {"errors": [api_exception for _ in range(2)],},
 }
 
-extended_error_expected = [["not found", "TestRequestID-0001"], ["not found", "TestRequestID-0001"]]
+extended_error_expected = [
+    ["not found", "TestRequestID-0001"],
+    ["not found", "TestRequestID-0001"],
+]
 
 
 class CocoonPrinterTests(unittest.TestCase):
@@ -198,7 +201,13 @@ class CocoonPrinterTests(unittest.TestCase):
         cls.logger = logger.LusidLogger("debug")
 
     def assert_responses(
-        self, num_items, expected_value, succ=None, err=None, failed=None, err_extended=False
+        self,
+        num_items,
+        expected_value,
+        succ=None,
+        err=None,
+        failed=None,
+        err_extended=False,
     ):
         if succ is not None:
             self.assertEqual(num_items, len(succ))
@@ -272,7 +281,13 @@ class CocoonPrinterTests(unittest.TestCase):
                 False,
             ),
             ("empty_response", empty_response_with_full_shape, 0, {}, False),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}, False),
+            (
+                "empty_response_missing_shape",
+                empty_response_missing_shape,
+                0,
+                {},
+                False,
+            ),
             (
                 "standard_response_with_extended_errors",
                 responses,
@@ -289,15 +304,22 @@ class CocoonPrinterTests(unittest.TestCase):
                     "err": extended_error_expected,
                 },
                 True,
-            )
+            ),
         ]
     )
     def test_format_instruments_response_success(
         self, _, response, num_items, expected_value, extended_errors,
     ):
-        succ, err, failed = format_instruments_response(response, extended_error_details=extended_errors)
+        succ, err, failed = format_instruments_response(
+            response, extended_error_details=extended_errors
+        )
         self.assert_responses(
-            num_items, expected_value, succ=succ, err=err, failed=failed, err_extended=extended_errors
+            num_items,
+            expected_value,
+            succ=succ,
+            err=err,
+            failed=failed,
+            err_extended=extended_errors,
         )
 
     @parameterized.expand(
@@ -316,14 +338,18 @@ class CocoonPrinterTests(unittest.TestCase):
                 2,
                 {"succ": ["ID00001", "ID00001"], "err": extended_error_expected},
                 True,
-            )
+            ),
         ]
     )
     def test_format_portfolios_response_success(
         self, _, response, num_items, expected_value, extended_errors,
     ):
-        succ, err = format_portfolios_response(response, extended_error_details=extended_errors)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
+        succ, err = format_portfolios_response(
+            response, extended_error_details=extended_errors
+        )
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, err_extended=extended_errors
+        )
 
     @parameterized.expand(
         [
@@ -340,15 +366,19 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["code", "code"], "err": extended_error_expected},
-                True
-            )
+                True,
+            ),
         ]
     )
     def test_format_transactions_response_success(
         self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_transactions_response(response, extended_error_details=extended_errors)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
+        succ, err = format_transactions_response(
+            response, extended_error_details=extended_errors
+        )
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, err_extended=extended_errors
+        )
 
     @parameterized.expand(
         [
@@ -364,7 +394,13 @@ class CocoonPrinterTests(unittest.TestCase):
                 False,
             ),
             ("empty_response", empty_response_with_full_shape, 0, {}, False),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}, False),
+            (
+                "empty_response_missing_shape",
+                empty_response_missing_shape,
+                0,
+                {},
+                False,
+            ),
             (
                 "standard_response_with_extended_errors",
                 responses,
@@ -381,7 +417,9 @@ class CocoonPrinterTests(unittest.TestCase):
     def test_format_quotes_response_success(
         self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err, failed = format_quotes_response(response, extended_error_details=extended_errors)
+        succ, err, failed = format_quotes_response(
+            response, extended_error_details=extended_errors
+        )
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
         self.assertEqual(num_items, len(failed))
@@ -391,7 +429,9 @@ class CocoonPrinterTests(unittest.TestCase):
                 expected_value["succ"][index],
                 row["quote_id.quote_series_id.instrument_id"],
             )
-        self.assert_responses(num_items, expected_value, err=err, err_extended=extended_errors)
+        self.assert_responses(
+            num_items, expected_value, err=err, err_extended=extended_errors
+        )
         for index, row in failed.iterrows():
             self.assertEqual(
                 expected_value["failed"][index],
@@ -405,7 +445,7 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["code", "code"], "err": ["not found", "not found"]},
-                False
+                False,
             ),
             ("empty_response", empty_response_with_full_shape, 0, {}, False),
             (
@@ -414,14 +454,18 @@ class CocoonPrinterTests(unittest.TestCase):
                 2,
                 {"succ": ["code", "code"], "err": extended_error_expected},
                 True,
-            )
+            ),
         ]
     )
     def test_format_holdings_response_success(
         self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_holdings_response(response, extended_error_details=extended_errors)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
+        succ, err = format_holdings_response(
+            response, extended_error_details=extended_errors
+        )
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, err_extended=extended_errors
+        )
 
     @parameterized.expand(
         [
@@ -439,14 +483,18 @@ class CocoonPrinterTests(unittest.TestCase):
                 2,
                 {"succ": ["ID00002", "ID00002"], "err": extended_error_expected},
                 True,
-            )
+            ),
         ]
     )
     def test_format_reference_portfolios_response_success(
         self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_reference_portfolios_response(response, extended_error_details=extended_errors)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
+        succ, err = format_reference_portfolios_response(
+            response, extended_error_details=extended_errors
+        )
+        self.assert_responses(
+            num_items, expected_value, succ=succ, err=err, err_extended=extended_errors
+        )
 
     # Test failure cases
 

--- a/tests/unit/cocoon/test_cocoon_printer.py
+++ b/tests/unit/cocoon/test_cocoon_printer.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import lusid
 import lusid.models as models
 import unittest
@@ -106,7 +105,18 @@ reference_portfolio_success = models.Portfolio(
     id=models.ResourceId(code="ID00002", scope="default test"),
 )
 
-api_exception = lusid.exceptions.ApiException(status="404", reason="not found")
+
+class MockHttpResp:
+    status = "404"
+    reason = "not found"
+    data = b'{"name":"TestFailure","errorDetails":[],"code":404,"type":"https://docs.lusid.com/#section/Error-Codes/404","title":"This is a test error title","status":404,"detail":"Test detail","instance":"https://test.lusid.com/app/insights/logs/TestRequestID-0001","extensions":{}}'
+
+    @classmethod
+    def getheaders(cls):
+        return {"lusid-meta-requestId": "TestRequestID-0001"}
+
+
+api_exception = lusid.exceptions.ApiException(http_resp=MockHttpResp())
 
 
 # build lusidtools responses
@@ -179,26 +189,32 @@ responses_no_success_field = {
     "reference_portfolios": {"errors": [api_exception for _ in range(2)],},
 }
 
+extended_error_expected = [["not found", "TestRequestID-0001"], ["not found", "TestRequestID-0001"]]
+
 
 class CocoonPrinterTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
-
         cls.logger = logger.LusidLogger("debug")
 
     def assert_responses(
-        self, num_items, expected_value, succ=None, err=None, failed=None
+        self, num_items, expected_value, succ=None, err=None, failed=None, err_extended=False
     ):
         if succ is not None:
             self.assertEqual(num_items, len(succ))
             for index, row in succ.iterrows():
                 self.assertEqual(expected_value["succ"][index], row[succ.columns[0]])
 
-        if err is not None:
+        if err is not None and not err_extended:
             self.assertEqual(num_items, len(err))
             for index, row in err.iterrows():
                 self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+
+        if err is not None and err_extended:
+            self.assertEqual(num_items, len(err))
+            for index, row in err.iterrows():
+                self.assertEqual(expected_value["err"][index][0], row[err.columns[0]])
+                self.assertEqual(expected_value["err"][index][1], row[err.columns[2]])
 
         if failed is not None:
             self.assertEqual(num_items, len(failed))
@@ -253,17 +269,35 @@ class CocoonPrinterTests(unittest.TestCase):
                     ],
                     "err": ["not found", "not found"],
                 },
+                False,
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {
+                    "succ": [
+                        "ClientInternal: imd_00001234",
+                        "ClientInternal: imd_00001234",
+                    ],
+                    "failed": [
+                        "ClientInternal: imd_00001234",
+                        "ClientInternal: imd_00001234",
+                    ],
+                    "err": extended_error_expected,
+                },
+                True,
+            )
         ]
     )
     def test_format_instruments_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors,
     ):
-        succ, err, failed = format_instruments_response(response)
+        succ, err, failed = format_instruments_response(response, extended_error_details=extended_errors)
         self.assert_responses(
-            num_items, expected_value, succ=succ, err=err, failed=failed
+            num_items, expected_value, succ=succ, err=err, failed=failed, err_extended=extended_errors
         )
 
     @parameterized.expand(
@@ -273,15 +307,23 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["ID00001", "ID00001"], "err": ["not found", "not found"]},
+                False,
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {"succ": ["ID00001", "ID00001"], "err": extended_error_expected},
+                True,
+            )
         ]
     )
     def test_format_portfolios_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors,
     ):
-        succ, err = format_portfolios_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err)
+        succ, err = format_portfolios_response(response, extended_error_details=extended_errors)
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
 
     @parameterized.expand(
         [
@@ -290,15 +332,23 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["code", "code"], "err": ["not found", "not found"]},
+                False,
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {"succ": ["code", "code"], "err": extended_error_expected},
+                True
+            )
         ]
     )
     def test_format_transactions_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_transactions_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err)
+        succ, err = format_transactions_response(response, extended_error_details=extended_errors)
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
 
     @parameterized.expand(
         [
@@ -311,15 +361,27 @@ class CocoonPrinterTests(unittest.TestCase):
                     "failed": ["BBG001MM1KV4", "BBG001MM1KV4"],
                     "err": ["not found", "not found"],
                 },
+                False,
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
-            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            ("empty_response_missing_shape", empty_response_missing_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {
+                    "succ": ["BBG001MM1KV4", "BBG001MM1KV4"],
+                    "failed": ["BBG001MM1KV4", "BBG001MM1KV4"],
+                    "err": extended_error_expected,
+                },
+                True,
+            ),
         ]
     )
     def test_format_quotes_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err, failed = format_quotes_response(response)
+        succ, err, failed = format_quotes_response(response, extended_error_details=extended_errors)
         self.assertEqual(num_items, len(succ))
         self.assertEqual(num_items, len(err))
         self.assertEqual(num_items, len(failed))
@@ -329,8 +391,7 @@ class CocoonPrinterTests(unittest.TestCase):
                 expected_value["succ"][index],
                 row["quote_id.quote_series_id.instrument_id"],
             )
-        for index, row in err.iterrows():
-            self.assertEqual(expected_value["err"][index], row[err.columns[0]])
+        self.assert_responses(num_items, expected_value, err=err, err_extended=extended_errors)
         for index, row in failed.iterrows():
             self.assertEqual(
                 expected_value["failed"][index],
@@ -344,15 +405,23 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["code", "code"], "err": ["not found", "not found"]},
+                False
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {"succ": ["code", "code"], "err": extended_error_expected},
+                True,
+            )
         ]
     )
     def test_format_holdings_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_holdings_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err)
+        succ, err = format_holdings_response(response, extended_error_details=extended_errors)
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
 
     @parameterized.expand(
         [
@@ -361,15 +430,23 @@ class CocoonPrinterTests(unittest.TestCase):
                 responses,
                 2,
                 {"succ": ["ID00002", "ID00002"], "err": ["not found", "not found"]},
+                False,
             ),
-            ("empty_response", empty_response_with_full_shape, 0, {}),
+            ("empty_response", empty_response_with_full_shape, 0, {}, False),
+            (
+                "standard_response_with_extended_errors",
+                responses,
+                2,
+                {"succ": ["ID00002", "ID00002"], "err": extended_error_expected},
+                True,
+            )
         ]
     )
     def test_format_reference_portfolios_response_success(
-        self, _, response, num_items, expected_value
+        self, _, response, num_items, expected_value, extended_errors
     ):
-        succ, err = format_reference_portfolios_response(response)
-        self.assert_responses(num_items, expected_value, succ=succ, err=err)
+        succ, err = format_reference_portfolios_response(response, extended_error_details=extended_errors)
+        self.assert_responses(num_items, expected_value, succ=succ, err=err, err_extended=extended_errors)
 
     # Test failure cases
 


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

This PR will add a flag to the cocoon printer formatting methods to enable extended error message reporting. 

By default the behavior is the same as before. With the new flag being passed, the errors in the response formatting will include the RequestIds and the ErrorDetails to help the user identify potential issues faster.
