### PR TITLE
Feature/se 1284.return full response

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1072,7 +1072,7 @@ def return_unmatched_transactions(
 
         unmatched_transactions.extend(
             [
-                {response.transaction_id: response.instrument_identifiers}
+                response
                 for response in response.values
             ]
         )
@@ -1110,8 +1110,7 @@ def filter_unmatched_transactions(
     filtered_unmatched_transactions = [
         unmatched_transaction
         for unmatched_transaction in unmatched_transactions
-        for key in unmatched_transaction.keys()
-        if key in valid_txids
+        if unmatched_transaction.transaction_id in valid_txids
     ]
 
     return filtered_unmatched_transactions

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1155,8 +1155,7 @@ def _unmatched_ids_holdings(
             )
         )
 
-    # Return a unique list of instrument_identifier dictionaries
-    return _unique_instrument_identifier_dictionaries(unmatched_instruments)
+    return unmatched_instruments
 
 
 def return_unmatched_instruments_from_holdings(
@@ -1187,46 +1186,11 @@ def return_unmatched_instruments_from_holdings(
     )
 
     # Create a list of instrument identifiers (with LUID_ZZZZZZZZ) from the response
-    unmatched_instruments = [
-        adjustment.instrument_identifiers
+    return [
+        adjustment
         for adjustment in response.adjustments
         if adjustment.instrument_uid == "LUID_ZZZZZZZZ"
     ]
-
-    # Return a unique list of instrument_identifier dictionaries
-    return _unique_instrument_identifier_dictionaries(unmatched_instruments)
-
-
-def _unique_instrument_identifier_dictionaries(unmatched_instruments: list):
-    """
-    The unmatched_identifier list may contain duplicate instrument_identifier dictionaries. This method
-    will remove any duplicates from that list with the following logic:
-
-    For each dictionary of instrument identifiers:
-        Sort the identifier and its values (for cases where the same identifiers exist but in a different order)
-        Store the identifier and values as a tuple
-    Create a set from the list of tuples to remove duplicate values
-    Map each of the tuples back into a dictionary and return them as a list.
-
-    Parameters
-    ----------
-    unmatched_instruments: list
-        A list of instrument_identifiers
-
-    Returns
-    -------
-    A unique list of instrument identifier dictionaries
-
-    """
-    return list(
-        map(
-            dict,
-            set(
-                tuple(sorted(identifiers.items()))
-                for identifiers in unmatched_instruments
-            ),
-        )
-    )
 
 
 @checkargs

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1059,12 +1059,7 @@ def return_unmatched_transactions(
 
         response = transactions_api.get_transactions(**kwargs)
 
-        unmatched_transactions.extend(
-            [
-                response
-                for response in response.values
-            ]
-        )
+        unmatched_transactions.extend([response for response in response.values])
 
         next_page = response.next_page
         done = response.next_page is None

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1,7 +1,6 @@
 import asyncio
 import lusid
 import pandas as pd
-import numpy as np
 import json
 from lusidtools import cocoon
 from lusidtools.cocoon.async_tools import run_in_executor, ThreadPool
@@ -16,7 +15,6 @@ from lusidtools.cocoon.utilities import (
 from lusidtools.cocoon.validator import Validator
 from datetime import datetime
 import pytz
-from lusidtools.logger import LusidLogger
 import logging
 
 
@@ -715,7 +713,7 @@ async def _construct_batches(
     domain_lookup: dict,
     sub_holding_keys: list,
     sub_holding_keys_scope: str,
-    return_unmatched_identifiers: bool,
+    return_unmatched_items: bool,
     **kwargs,
 ):
     """
@@ -747,8 +745,8 @@ async def _construct_batches(
         The sub holding keys to use
     sub_holding_keys_scope : str
         The scope to use for the sub-holding keys
-    return_unmatched_identifiers : bool
-        Whether unmatched identifiers should be returned for transaction or holding upserts
+    return_unmatched_items : bool
+        Whether items with unmatched identifiers should be returned for transaction or holding upserts
     kwargs
         Arguments specific to each call e.g. effective_at for holdings
 
@@ -912,8 +910,8 @@ async def _construct_batches(
     }
 
     # For transactions or holdings file types, optionally return unmatched identifiers with the responses
-    if return_unmatched_identifiers is True and file_type in ["transaction", "holding"]:
-        returned_response["unmatched_identifiers"] = unmatched_identifiers(
+    if return_unmatched_items is True and file_type in ["transaction", "holding"]:
+        returned_response["unmatched_items"] = unmatched_items(
             api_factory=api_factory,
             scope=kwargs.get("scope", None),
             data_frame=data_frame,
@@ -926,7 +924,7 @@ async def _construct_batches(
 
 
 @checkargs
-def unmatched_identifiers(
+def unmatched_items(
     api_factory: lusid.utilities.ApiClientFactory,
     scope: str,
     data_frame: pd.DataFrame,
@@ -935,8 +933,8 @@ def unmatched_identifiers(
     sync_batches: list = None,
 ):
     """
-    This method orchestrates the identification of unresolved identifiers that were part of the holdings or transactions
-    upload (i.e. where the instrument_uid is LUID_ZZZZZZ)
+    This method orchestrates the identification of holdings or transactions objects that were successfully uploaded
+    but did not resolve to known identifiers (i.e. where the instrument_uid is LUID_ZZZZZZ)
 
     Parameters
     ----------
@@ -956,15 +954,10 @@ def unmatched_identifiers(
     Returns
     -------
     responses: list
-        A list to be appended to the ultimate response for load_from_data_frame.
-
-        Where data_type == "transaction", the returned list will contain objects with the structure:
-            {transaction_id: instrument_identifiers}
-
-        Where data_type == "holding", the returned list will be a unique list of instrument_identifiers.
+        A list of objects to be appended to the ultimate response for load_from_data_frame.
     """
     if file_type == "transaction":
-        return _unmatched_ids_transactions(
+        return _unmatched_transactions(
             api_factory=api_factory,
             scope=scope,
             data_frame=data_frame,
@@ -972,12 +965,12 @@ def unmatched_identifiers(
             sync_batches=sync_batches,
         )
     elif file_type == "holding":
-        return _unmatched_ids_holdings(
+        return _unmatched_holdings(
             api_factory=api_factory, scope=scope, sync_batches=sync_batches,
         )
 
 
-def _unmatched_ids_transactions(
+def _unmatched_transactions(
     api_factory: lusid.utilities.ApiClientFactory,
     scope: str,
     data_frame: pd.DataFrame,
@@ -1001,11 +994,7 @@ def _unmatched_ids_transactions(
     Returns
     -------
     responses: list
-        A list to be appended to the ultimate response for load_from_data_frame.
-
-        The returned list will contain objects with the structure:
-            {transaction_id: instrument_identifiers}
-
+        A list of transaction objects to be appended to the ultimate response for load_from_data_frame.
     """
     # Extract a list of portfolio codes from the sync_batches
     portfolio_codes = extract_unique_portfolio_codes(sync_batches)
@@ -1048,7 +1037,7 @@ def return_unmatched_transactions(
 
     Returns
     -------
-    A list of objects with the structure { transaction_id: instrument_identifiers }.
+    A list of transaction objects with the structure.
     """
     transactions_api = api_factory.build(lusid.api.TransactionPortfoliosApi)
     done = False
@@ -1097,11 +1086,11 @@ def filter_unmatched_transactions(
     mapping_required : dict
         The required mapping from load_from_data_frame that helps identify the transaction_id column in the DataFrame
     unmatched_transactions : list
-         A list of objects with the structure { transaction_id: instrument_identifiers }
+         A list of transaction objects.
 
     Returns
     -------
-    A filtered list of unmatched_transactions.
+    A filtered list of transaction objects.
     """
     # Create a unique list of transaction_ids from the dataframe
     valid_txids = set(data_frame[mapping_required.get("transaction_id")])
@@ -1116,7 +1105,7 @@ def filter_unmatched_transactions(
     return filtered_unmatched_transactions
 
 
-def _unmatched_ids_holdings(
+def _unmatched_holdings(
     api_factory: lusid.utilities.ApiClientFactory,
     scope: str,
     sync_batches: list = None,
@@ -1136,33 +1125,30 @@ def _unmatched_ids_holdings(
     Returns
     -------
     responses: list
-        A list to be appended to the ultimate response for load_from_data_frame.
-
-        The returned list will be a unique list of instrument_identifiers.
-
+        A list of holding objects to be appended to the ultimate response for load_from_data_frame.
     """
     # Extract a list of tuples of portfolio codes and effective at times from sync_batches
     code_tuples = extract_unique_portfolio_codes_effective_at_tuples(sync_batches)
 
-    # Create empty list to hold instrument identifiers dictionaries that have not been resolved
-    unmatched_instruments = []
+    # Create empty list to hold holdings that have not been resolved
+    unmatched_holdings = []
 
     # For each holding adjustment in the upload, check whether any contained unresolved instruments and append to list
     for code_tuple in code_tuples:
-        unmatched_instruments.extend(
-            return_unmatched_instruments_from_holdings(
+        unmatched_holdings.extend(
+            return_unmatched_holdings(
                 api_factory=api_factory, scope=scope, code_tuple=code_tuple,
             )
         )
 
-    return unmatched_instruments
+    return unmatched_holdings
 
 
-def return_unmatched_instruments_from_holdings(
+def return_unmatched_holdings(
     api_factory: lusid.utilities.ApiClientFactory, scope: str, code_tuple: (str, str),
 ):
     """
-    Call the get holdings adjustments api and return a list of instruments that have unresolved identifiers.
+    Call the get holdings adjustments api and return a list of holding objects that have unresolved identifiers.
 
     Parameters
     ----------
@@ -1176,7 +1162,7 @@ def return_unmatched_instruments_from_holdings(
 
     Returns
     -------
-    A unique list of instrument identifier dictionaries
+    A list of holding objects.
 
     """
     transactions_api = api_factory.build(lusid.api.TransactionPortfoliosApi)
@@ -1185,7 +1171,7 @@ def return_unmatched_instruments_from_holdings(
         scope=scope, code=code_tuple[0], effective_at=str(DateOrCutLabel(code_tuple[1]))
     )
 
-    # Create a list of instrument identifiers (with LUID_ZZZZZZZZ) from the response
+    # Create a list of holding objects with unmatched identifiers (e.g. with LUID_ZZZZZZZZ) from the response
     return [
         adjustment
         for adjustment in response.adjustments
@@ -1211,7 +1197,7 @@ def load_from_data_frame(
     holdings_adjustment_only: bool = False,
     thread_pool_max_workers: int = 5,
     sub_holding_keys_scope: str = None,
-    return_unmatched_identifiers: bool = False,
+    return_unmatched_items: bool = False,
 ):
     """
 
@@ -1250,10 +1236,11 @@ def load_from_data_frame(
         The maximum number of workers to use in the thread pool used by the function
     sub_holding_keys_scope : str
         The scope to add the sub-holding keys to
-    return_unmatched_identifiers : bool
-        When loading transactions or holdings, a 'True' flag will return a list of identifiers that were
-        unmatched at the time of the upsert (i.e. where instrument_uid is LUID_ZZZZZZ). This parameter
-        will be ignored for file types other than transactions or holdings
+    return_unmatched_items : bool
+        When loading transactions or holdings, a 'True' flag will return a list of the transaction or holding
+        objects where their instruments were unmatched at the time of the upsert
+        (i.e. where instrument_uid is LUID_ZZZZZZ). This parameter will be ignored for file types other than
+        transactions or holdings
     Returns
     -------
     responses: dict
@@ -1594,7 +1581,7 @@ def load_from_data_frame(
             domain_lookup=domain_lookup,
             sub_holding_keys=sub_holding_keys,
             sub_holding_keys_scope=sub_holding_keys_scope,
-            return_unmatched_identifiers=return_unmatched_identifiers,
+            return_unmatched_items=return_unmatched_items,
             **keyword_arguments,
         ),
         loop,

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -30,6 +30,24 @@ def holding_instrument_identifiers(fake1=False, fake2=False):
     return [instrument for instrument in [fake1, fake2] if instrument]
 
 
+def extract_unique_identifiers_from_holdings_response(response):
+    unmatched_instruments = [
+        holding_adjustment.instrument_identifiers for
+        holding_adjustment in
+        response["holdings"].get("unmatched_identifiers", [])
+    ]
+
+    return list(
+        map(
+            dict,
+            set(
+                tuple(sorted(identifiers.items()))
+                for identifiers in unmatched_instruments
+            ),
+        )
+    )
+
+
 class CocoonTestsHoldings(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -771,6 +789,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date.csv",
                 None,
                 False,
+                0,
                 holding_instrument_identifiers(fake1=False, fake2=False),
             ],
             [
@@ -778,6 +797,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-one-unmatched-instrument.csv",
                 None,
                 False,
+                1,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -786,6 +806,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-incorrect-sedol-correct_isin_clientInternal_should_resolve.csv",
                 None,
                 False,
+                0,
                 holding_instrument_identifiers(fake1=False, fake2=False),
             ],
             [
@@ -793,6 +814,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-one-unmatched-instrument-duplicated-in-two-adjustments.csv",
                 None,
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -800,6 +822,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-two-unmatched-instruments-separate-adjustments.csv",
                 None,
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -807,6 +830,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-two-unmatched-instruments-single-adjustment.csv",
                 None,
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -814,6 +838,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-unmatched-instrument-in-two-adjustments-one-portfolio-two-dates.csv",
                 None,
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -821,6 +846,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-same-date-one-unmatched-instrument-duplicated-in-two-adjustments-two-portfolios.csv",
                 None,
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -828,6 +854,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-two-dates-two-unmatched-instruments-separate-adjustments-two-portfolios.csv",
                 None,
                 False,
+                4,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -835,6 +862,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-one-shk-one-date-two-instruments.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -842,6 +870,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-one-shk-two-dates-two-instruments.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -849,6 +878,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-two-shks-one-date-one-instrument.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -856,6 +886,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-two-shks-one-date-two-instruments.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -863,6 +894,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-two-shks-two-dates-two-instruments.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -870,6 +902,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-two-shks-two-dates-one-instrument.csv",
                 ["Security Description"],
                 False,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -877,6 +910,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-two-shks-two-dates-one-instrument.csv",
                 ["Security Description"],
                 True,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -884,6 +918,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-one-portfolio-one-shk-two-dates-two-instruments.csv",
                 ["Security Description"],
                 True,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -891,6 +926,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-two-unmatched-instruments-single-adjustment.csv",
                 None,
                 True,
+                2,
                 holding_instrument_identifiers(fake1=True, fake2=True),
             ],
             [
@@ -898,6 +934,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-one-unmatched-instrument.csv",
                 None,
                 True,
+                1,
                 holding_instrument_identifiers(fake1=True, fake2=False),
             ],
             [
@@ -905,6 +942,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 "data/holdings-example-unique-date-two-unmatched-instruments-single-adjustment_three_unique_ids.csv",
                 None,
                 True,
+                2,
                 [
                     {
                         "Instrument/default/Sedol": "FAKESEDOL1",
@@ -924,6 +962,7 @@ class CocoonTestsHoldings(unittest.TestCase):
         file_name,
         sub_holding_keys,
         holdings_adjustment_only,
+        expected_holdings_in_response,
         expected_unmatched_identifiers,
     ) -> None:
         """
@@ -995,10 +1034,12 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 0)
 
+        self.assertEqual(len(holding_responses["holdings"]["unmatched_identifiers"]), expected_holdings_in_response)
+
         # Assert that the unmatched_identifiers code is hit when the return_unmatched_identifiers is set to True and
         # Check that the lists contain the same elements, in any order (the assert name is misleading)
         self.assertCountEqual(
-            holding_responses["holdings"].get("unmatched_identifiers", False),
+            extract_unique_identifiers_from_holdings_response(holding_responses),
             expected_unmatched_identifiers,
         )
 

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -34,7 +34,7 @@ def extract_unique_identifiers_from_holdings_response(response):
     unmatched_instruments = [
         holding_adjustment.instrument_identifiers for
         holding_adjustment in
-        response["holdings"].get("unmatched_identifiers", [])
+        response["holdings"].get("unmatched_items", [])
     ]
 
     return list(
@@ -956,7 +956,7 @@ class CocoonTestsHoldings(unittest.TestCase):
             ],
         ]
     )
-    def test_load_from_data_frame_holdings_success_with_unmatched_identifiers(
+    def test_load_from_data_frame_holdings_success_with_unmatched_items(
         self,
         _,
         file_name,
@@ -991,7 +991,7 @@ class CocoonTestsHoldings(unittest.TestCase):
         property_columns = ["Prime Broker"]
         properties_scope = "operations001"
         sub_holding_key_scope = None
-        return_unmatched_identifiers = True
+        return_unmatched_items = True
         expected_outcome = lusid.models.Version
 
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
@@ -1027,17 +1027,17 @@ class CocoonTestsHoldings(unittest.TestCase):
             sub_holding_keys=sub_holding_keys,
             holdings_adjustment_only=holdings_adjustment_only,
             sub_holding_keys_scope=sub_holding_key_scope,
-            return_unmatched_identifiers=return_unmatched_identifiers,
+            return_unmatched_items=return_unmatched_items,
         )
 
         self.assertGreater(len(holding_responses["holdings"]["success"]), 0)
 
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 0)
 
-        self.assertEqual(len(holding_responses["holdings"]["unmatched_identifiers"]), expected_holdings_in_response)
+        # Assert that the number of holdings returned are as expected
+        self.assertEqual(len(holding_responses["holdings"]["unmatched_items"]), expected_holdings_in_response)
 
-        # Assert that the unmatched_identifiers code is hit when the return_unmatched_identifiers is set to True and
-        # Check that the lists contain the same elements, in any order (the assert name is misleading)
+        # Assert that the holdings returned only contain the instrument identifiers that did not resolve
         self.assertCountEqual(
             extract_unique_identifiers_from_holdings_response(holding_responses),
             expected_unmatched_identifiers,

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -32,9 +32,8 @@ def holding_instrument_identifiers(fake1=False, fake2=False):
 
 def extract_unique_identifiers_from_holdings_response(response):
     unmatched_instruments = [
-        holding_adjustment.instrument_identifiers for
-        holding_adjustment in
-        response["holdings"].get("unmatched_items", [])
+        holding_adjustment.instrument_identifiers
+        for holding_adjustment in response["holdings"].get("unmatched_items", [])
     ]
 
     return list(
@@ -1035,7 +1034,10 @@ class CocoonTestsHoldings(unittest.TestCase):
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 0)
 
         # Assert that the number of holdings returned are as expected
-        self.assertEqual(len(holding_responses["holdings"]["unmatched_items"]), expected_holdings_in_response)
+        self.assertEqual(
+            len(holding_responses["holdings"]["unmatched_items"]),
+            expected_holdings_in_response,
+        )
 
         # Assert that the holdings returned only contain the instrument identifiers that did not resolve
         self.assertCountEqual(

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -29,7 +29,7 @@ def transaction_and_instrument_identifiers(trd_0003=False, trd_0004=False):
                 client_internal: "THIS_WILL_NOT_RESOLVE_1",
                 sedol: "FAKESEDOL1",
                 name: "THIS_WILL_NOT_RESOLVE_1",
-            }
+            },
         )
     else:
         trd_0003 = None
@@ -41,7 +41,7 @@ def transaction_and_instrument_identifiers(trd_0003=False, trd_0004=False):
                 client_internal: "THIS_WILL_NOT_RESOLVE_2",
                 sedol: "FAKESEDOL2",
                 name: "THIS_WILL_NOT_RESOLVE_2",
-            }
+            },
         )
     else:
         trd_0004 = None
@@ -51,9 +51,8 @@ def transaction_and_instrument_identifiers(trd_0003=False, trd_0004=False):
 
 def dict_for_comparison(list_of_transactions):
     return {
-        transaction.transaction_id: transaction.instrument_identifiers for
-        transaction in
-        list_of_transactions
+        transaction.transaction_id: transaction.instrument_identifiers
+        for transaction in list_of_transactions
     }
 
 
@@ -336,19 +335,12 @@ class CocoonTestsTransactions(unittest.TestCase):
                 "Test standard transaction load with two unresolved instruments",
                 "data/global-fund-combined-transactions-unresolved-instruments.csv",
                 True,
-                [
-                    "unresolved_tx01",
-                    "unresolved_tx02",
-                ],
+                ["unresolved_tx01", "unresolved_tx02",],
             ],
         ]
     )
     def test_load_from_data_frame_transactions_success_with_correct_unmatched_identifiers(
-        self,
-        _,
-        file_name,
-        return_unmatched_items,
-        expected_unmatched_transactions,
+        self, _, file_name, return_unmatched_items, expected_unmatched_transactions,
     ) -> None:
         """
         Test that transactions are uploaded and have the expected response from load_from_data_frame
@@ -409,16 +401,15 @@ class CocoonTestsTransactions(unittest.TestCase):
         # First check the count of transactions
         self.assertEqual(
             len(responses["transactions"].get("unmatched_items", False)),
-            len(expected_unmatched_transactions)
+            len(expected_unmatched_transactions),
         )
         # Then check the transaction ids are the ones expected
         self.assertCountEqual(
             [
-                transaction.transaction_id for
-                transaction in
-                responses["transactions"].get("unmatched_items", [])
+                transaction.transaction_id
+                for transaction in responses["transactions"].get("unmatched_items", [])
             ],
-            expected_unmatched_transactions
+            expected_unmatched_transactions,
         )
 
         self.assertTrue(
@@ -489,7 +480,10 @@ class CocoonTestsTransactions(unittest.TestCase):
         # Assert that there are only two values returned
         self.assertEqual(len(response), 2)
         # Assert that the transaction ids and instrument identifiers from the returned transactions match expectations
-        response_dict = {transaction.transaction_id: transaction.instrument_identifiers for transaction in response}
+        response_dict = {
+            transaction.transaction_id: transaction.instrument_identifiers
+            for transaction in response
+        }
         self.assertEqual(
             response_dict.get("trd_0003"),
             {
@@ -566,7 +560,7 @@ class CocoonTestsTransactions(unittest.TestCase):
         # Assert that the transaction ids and identifiers from the transactions returned match up to the expected ones
         self.assertCountEqual(
             dict_for_comparison(filtered_unmatched_transactions),
-            dict_for_comparison(expected_filtered_unmatched_transactions)
+            dict_for_comparison(expected_filtered_unmatched_transactions),
         )
 
     @lusid_feature("T8-14")
@@ -644,8 +638,7 @@ class CocoonTestsTransactions(unittest.TestCase):
 
         # Assert that the unmatched_items returned are as expected
         self.assertEqual(
-            len(transactions_response["transactions"].get("unmatched_items", [])),
-            2001,
+            len(transactions_response["transactions"].get("unmatched_items", [])), 2001,
         )
 
         # Delete the portfolio at the end of the test

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -347,14 +347,14 @@ class CocoonTestsTransactions(unittest.TestCase):
         self,
         _,
         file_name,
-        return_unmatched_identifiers,
+        return_unmatched_items,
         expected_unmatched_transactions,
     ) -> None:
         """
         Test that transactions are uploaded and have the expected response from load_from_data_frame
 
         :param str file_name: The name of the test data file
-        :param bool return_unmatched_identifiers: A flag to request the return of all unmatched instrument identifiers
+        :param bool return_unmatched_items: A flag to request the return of all objects with unresolved instruments
         :param expected_unmatched_transactions: The expected unmatched transactions appended to the response
 
         :return: None
@@ -398,7 +398,7 @@ class CocoonTestsTransactions(unittest.TestCase):
             property_columns=property_columns,
             properties_scope=properties_scope,
             batch_size=batch_size,
-            return_unmatched_identifiers=return_unmatched_identifiers,
+            return_unmatched_items=return_unmatched_items,
         )
 
         self.assertGreater(len(responses["transactions"]["success"]), 0)
@@ -408,7 +408,7 @@ class CocoonTestsTransactions(unittest.TestCase):
         # Assert that the unmatched_transactions returned are as expected for each case
         # First check the count of transactions
         self.assertEqual(
-            len(responses["transactions"].get("unmatched_identifiers", False)),
+            len(responses["transactions"].get("unmatched_items", False)),
             len(expected_unmatched_transactions)
         )
         # Then check the transaction ids are the ones expected
@@ -416,7 +416,7 @@ class CocoonTestsTransactions(unittest.TestCase):
             [
                 transaction.transaction_id for
                 transaction in
-                responses["transactions"].get("unmatched_identifiers", [])
+                responses["transactions"].get("unmatched_items", [])
             ],
             expected_unmatched_transactions
         )
@@ -488,7 +488,7 @@ class CocoonTestsTransactions(unittest.TestCase):
 
         # Assert that there are only two values returned
         self.assertEqual(len(response), 2)
-        # Assert that the transaction ids and instrument identifiers match
+        # Assert that the transaction ids and instrument identifiers from the returned transactions match expectations
         response_dict = {transaction.transaction_id: transaction.instrument_identifiers for transaction in response}
         self.assertEqual(
             response_dict.get("trd_0003"),
@@ -535,7 +535,7 @@ class CocoonTestsTransactions(unittest.TestCase):
             ],
         ]
     )
-    def test_filter_unmatched_transactions_method_only_returns_transaction_ids_originally_present_in_dataframe(
+    def test_filter_unmatched_transactions_method_only_returns_transactions_originally_present_in_dataframe(
         self,
         _,
         data_frame_path,
@@ -563,6 +563,7 @@ class CocoonTestsTransactions(unittest.TestCase):
             unmatched_transactions=unmatched_transactions,
         )
 
+        # Assert that the transaction ids and identifiers from the transactions returned match up to the expected ones
         self.assertCountEqual(
             dict_for_comparison(filtered_unmatched_transactions),
             dict_for_comparison(expected_filtered_unmatched_transactions)
@@ -635,15 +636,15 @@ class CocoonTestsTransactions(unittest.TestCase):
             file_type="transactions",
             identifier_mapping=identifier_mapping,
             batch_size=None,
-            return_unmatched_identifiers=True,
+            return_unmatched_items=True,
         )
 
         self.assertGreater(len(transactions_response["transactions"]["success"]), 0)
         self.assertEqual(len(transactions_response["transactions"]["errors"]), 0)
 
-        # Assert that the unmatched_identifiers returned are as expected
+        # Assert that the unmatched_items returned are as expected
         self.assertEqual(
-            len(transactions_response["transactions"].get("unmatched_identifiers", [])),
+            len(transactions_response["transactions"].get("unmatched_items", [])),
             2001,
         )
 


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

A recently added flag within `load_from_data_frame()` called `return_unmatched_identifiers` was useful in showing which instrument identifiers did not resolve when uploading transactions or holdings, but there was not always enough information to be able to quickly identify which transactions or holdings were affected. 

This change renames that feature flag to `return_unmatched_items` and updates the logic so that the entire transaction or holding object is returned when the instrument does not successfully resolve in LUSID. This will give all users all the information they require to quickly identify which items in their upload did not resolve, as well as providing them with helpful associated metadata that they can use to improve their workflow to correct the identifiers. 


