### PR TITLE
SE-1326: Extend DFQ where functionality

### DIFF
--- a/lusidtools/lpt/lse.py
+++ b/lusidtools/lpt/lse.py
@@ -99,7 +99,7 @@ class Caller:
                 result = fn(*args, **(adjKwargs))
                 request_id = result[2].get("lusid-meta-requestId", "n/a")
             except self.exceptionClass as err:
-                data = {} if err.body == "" else json.loads(err.body)
+                data = {} if err.body == "" or err.body == b"" else json.loads(err.body)
 
                 instance = data.get("instance", "n/a")
                 s = instance.split("insights/logs/")

--- a/tests/integration/cocoon/test_async_tools.py
+++ b/tests/integration/cocoon/test_async_tools.py
@@ -40,10 +40,10 @@ class CocoonTestsAsyncTools(unittest.TestCase):
                 5,
             ],
             [
-                "Standard load with ~700 portfolios in 5 batches with max_threads per batch of 20",
+                "Standard load with ~700 portfolios in 5 batches with max_threads per batch of 10",
                 "data/holdings-example-large.csv",
                 5,
-                20,
+                10,
             ],
         ]
     )


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

Currently the dfq -w argument only supports exact = and ! 

This PR extents that functionality to include <, >, <=, >= to allow queries like 

-w "diff_cost<3" "diff_cost>-3" "Transaction/SHK/CATEGORY!=Investments Long"
(where the diff is between -3 and 3, and CATEGORY is not "Investments Long")