### PR TITLE
SE-1327: Increase GitHub Actions timeout to 45 mins for tests

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   cron-build-and-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
 

--- a/.github/workflows/run-tests-on-pull.yml
+++ b/.github/workflows/run-tests-on-pull.yml
@@ -41,7 +41,7 @@ jobs:
     strategy: 
       max-parallel: 1
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass (bypassing)

# Description of the PR

Updated the timeout for the cron and run-lpt-tests GHA
