### PR TITLE
SE-1323: Handle getholding lusid exception within LPT

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1166,12 +1166,16 @@ def return_unmatched_holdings(
     # make sure to gracefully handle the exception so that any LUSID error from the main upload is not suppressed.
     try:
         response = transactions_api.get_holdings_adjustment(
-            scope=scope, code=code_tuple[0], effective_at=str(DateOrCutLabel(code_tuple[1]))
+            scope=scope,
+            code=code_tuple[0],
+            effective_at=str(DateOrCutLabel(code_tuple[1])),
         )
     except lusid.ApiException as e:
         if "HoldingsAdjustmentDoesNotExist" in str(e.body):
-            logging.info(f"While validating holding upload, LUSID was unable to find any holdings within portfolio "
-                         f"{code_tuple[0]} for effectiveAt {str(DateOrCutLabel(code_tuple[1]))}.")
+            logging.info(
+                f"While validating holding upload, LUSID was unable to find any holdings within portfolio "
+                f"{code_tuple[0]} for effectiveAt {str(DateOrCutLabel(code_tuple[1]))}."
+            )
             return []
 
     # Create a list of holding objects with unmatched identifiers (e.g. with LUID_ZZZZZZZZ) from the response

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1162,9 +1162,17 @@ def return_unmatched_holdings(
     """
     transactions_api = api_factory.build(lusid.api.TransactionPortfoliosApi)
 
-    response = transactions_api.get_holdings_adjustment(
-        scope=scope, code=code_tuple[0], effective_at=str(DateOrCutLabel(code_tuple[1]))
-    )
+    # In case a holdings check occurs for a portfolio code and effective at combination that contain no holdings,
+    # make sure to gracefully handle the exception so that any LUSID error from the main upload is not suppressed.
+    try:
+        response = transactions_api.get_holdings_adjustment(
+            scope=scope, code=code_tuple[0], effective_at=str(DateOrCutLabel(code_tuple[1]))
+        )
+    except lusid.ApiException as e:
+        if "HoldingsAdjustmentDoesNotExist" in str(e.body):
+            logging.info(f"While validating holding upload, LUSID was unable to find any holdings within portfolio "
+                         f"{code_tuple[0]} for effectiveAt {str(DateOrCutLabel(code_tuple[1]))}.")
+            return []
 
     # Create a list of holding objects with unmatched identifiers (e.g. with LUID_ZZZZZZZZ) from the response
     return [

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1,6 +1,8 @@
 import unittest
 from pathlib import Path
 import pandas as pd
+from datetime import datetime
+import pytz
 from lusidfeature import lusid_feature
 
 from lusidtools import cocoon as cocoon
@@ -1057,3 +1059,55 @@ class CocoonTestsHoldings(unittest.TestCase):
             self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(
                 scope=scope, code=portfolio.id.code
             )
+
+    @lusid_feature(
+        "T3-42",
+    )
+    def test_return_unmatched_holding_handles_empty_holdings_exception_in_lusid(self):
+        """
+        Test that the get holdings call to LUSID handles cases where there are no holdings present for a
+        given portfolio code and effective at combination.
+
+        :return: None
+        """
+        portfolio_code_and_scope = "set_holdings_test"
+        effective_at_datetime_for_portfolio = datetime(2020, 1, 1, tzinfo=pytz.utc)
+        base_currency = "GBP"
+        effective_at_str_for_holdings = "2020-01-01T12:00:00"
+        code_tuple = (portfolio_code_and_scope, effective_at_str_for_holdings)
+
+        # Create an empty portfolio for the test, but handle situations where the portfolio already exists
+        try:
+            portfolio_setup_response = self.api_factory.build(lusid.api.TransactionPortfoliosApi).create_portfolio(
+                scope=portfolio_code_and_scope,
+                create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
+                    display_name=portfolio_code_and_scope,
+                    description=portfolio_code_and_scope,
+                    code=portfolio_code_and_scope,
+                    created=effective_at_datetime_for_portfolio,
+                    base_currency=base_currency,
+                )
+            )
+
+            # Assert that the portfolio was created successfully
+            self.assertIsInstance(portfolio_setup_response, lusid.models.Portfolio)
+
+        except lusid.ApiException as e:
+            if "PortfolioWithIdAlreadyExists" not in str(e.body):
+                raise e
+
+        # Call the return_unmatched_holdings method where there are no holdings
+        unmatched_holdings_response = cocoon.cocoon.return_unmatched_holdings(
+            api_factory=self.api_factory,
+            scope=portfolio_code_and_scope,
+            code_tuple=code_tuple
+        )
+
+        # Assert that the unmatched holdings response does not throw an error, and returns an empty list
+        self.assertEqual([], unmatched_holdings_response)
+
+        # Delete the portfolio at the end of the test
+        self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(
+            scope=portfolio_code_and_scope,
+            code=portfolio_code_and_scope
+        )

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1060,9 +1060,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                 scope=scope, code=portfolio.id.code
             )
 
-    @lusid_feature(
-        "T3-42",
-    )
+    @lusid_feature("T3-42",)
     def test_return_unmatched_holding_handles_empty_holdings_exception_in_lusid(self):
         """
         Test that the get holdings call to LUSID handles cases where there are no holdings present for a
@@ -1078,7 +1076,9 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         # Create an empty portfolio for the test, but handle situations where the portfolio already exists
         try:
-            portfolio_setup_response = self.api_factory.build(lusid.api.TransactionPortfoliosApi).create_portfolio(
+            portfolio_setup_response = self.api_factory.build(
+                lusid.api.TransactionPortfoliosApi
+            ).create_portfolio(
                 scope=portfolio_code_and_scope,
                 create_transaction_portfolio_request=lusid.models.CreateTransactionPortfolioRequest(
                     display_name=portfolio_code_and_scope,
@@ -1086,7 +1086,7 @@ class CocoonTestsHoldings(unittest.TestCase):
                     code=portfolio_code_and_scope,
                     created=effective_at_datetime_for_portfolio,
                     base_currency=base_currency,
-                )
+                ),
             )
 
             # Assert that the portfolio was created successfully
@@ -1100,7 +1100,7 @@ class CocoonTestsHoldings(unittest.TestCase):
         unmatched_holdings_response = cocoon.cocoon.return_unmatched_holdings(
             api_factory=self.api_factory,
             scope=portfolio_code_and_scope,
-            code_tuple=code_tuple
+            code_tuple=code_tuple,
         )
 
         # Assert that the unmatched holdings response does not throw an error, and returns an empty list
@@ -1108,6 +1108,5 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         # Delete the portfolio at the end of the test
         self.api_factory.build(lusid.api.PortfoliosApi).delete_portfolio(
-            scope=portfolio_code_and_scope,
-            code=portfolio_code_and_scope
+            scope=portfolio_code_and_scope, code=portfolio_code_and_scope
         )


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

If a load_from_data_frame encounters an error with a holdings upload, the return_unmatched_items logic (if a True parameter is provided) may obscure the load error by raising it's own exception. The return_unmatched_items error should be handled gracefully and the main lusid error should returned as normal to the user so that they can debug the primary issue. 