### PR TITLE
SE-1437: Do not validate upload if any errors

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -913,7 +913,7 @@ async def _construct_batches(
     if check_for_unmatched_items(
         flag=return_unmatched_items,
         file_type=file_type,
-        returned_response=returned_response
+        returned_response=returned_response,
     ):
         returned_response["unmatched_items"] = unmatched_items(
             api_factory=api_factory,

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -910,10 +910,7 @@ async def _construct_batches(
     }
 
     # For successful transactions or holdings file types, optionally return unmatched identifiers with the responses
-    if check_for_unmatched_items(
-        flag=return_unmatched_items,
-        file_type=file_type,
-    ):
+    if check_for_unmatched_items(flag=return_unmatched_items, file_type=file_type,):
         returned_response["unmatched_items"] = unmatched_items(
             api_factory=api_factory,
             scope=kwargs.get("scope", None),

--- a/tests/integration/cocoon/data/holdings-example-duplicate-shk.csv
+++ b/tests/integration/cocoon/data/holdings-example-duplicate-shk.csv
@@ -1,0 +1,3 @@
+,FundCode,Created Date,Effective Date,Prime Broker,Local Currency Code,Quantity,Local Price,Local Market Value,Base Market Value,Security Description,ISIN Security Identifier,SEDOL Security Identifier,Client Internal,Buy_Currency,swap,is_cash_with_currency
+0,Portfolio-Z,05/02/2019,02/07/2019,UBS,GBP,2500,56.76,141900,141900,Lloyds Banking Group PLC,GB0008706128,870612,LLOY LN,GBP,TRUE,
+1,Portfolio-Z,05/02/2019,02/07/2019,UBS,GBP,2500,56.76,141900,141900,Lloyds Banking Group PLC,GB0008706128,870612,LLOY LN,GBP,TRUE,

--- a/tests/integration/cocoon/data/holdings-example-single-holding.csv
+++ b/tests/integration/cocoon/data/holdings-example-single-holding.csv
@@ -1,0 +1,2 @@
+,FundCode,Created Date,Effective Date,Prime Broker,Local Currency Code,Quantity,Local Price,Local Market Value,Base Market Value,Security Description,ISIN Security Identifier,SEDOL Security Identifier,Client Internal,Buy_Currency,swap,is_cash_with_currency
+0,Portfolio-Z,05/02/2019,02/07/2019,UBS,GBP,2500,56.76,141900,141900,Lloyds Banking Group PLC,GB0008706128,870612,LLOY LN,GBP,TRUE,

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1167,7 +1167,9 @@ class CocoonTestsHoldings(unittest.TestCase):
         sub_holding_key_scope = None
         return_unmatched_items = True
         holdings_adjustment_only = False
-        failed_unmatched_items_check = ["Please resolve all upload errors to check for unmatched items."]
+        failed_unmatched_items_check = [
+            "Please resolve all upload errors to check for unmatched items."
+        ]
 
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
 
@@ -1210,14 +1212,17 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 1)
 
-        # Assert that the ApiError thrown by LUSID is what is expected, given the input data 
+        # Assert that the ApiError thrown by LUSID is what is expected, given the input data
         self.assertEqual(
             json.loads(holding_responses["holdings"]["errors"][0].body)["name"],
             error_name,
         )
 
         # Assert that there is no 'unmatched_item' field if the input data resulted in no successful uploads
-        self.assertEqual(holding_responses["holdings"].get("unmatched_items"), failed_unmatched_items_check)
+        self.assertEqual(
+            holding_responses["holdings"].get("unmatched_items"),
+            failed_unmatched_items_check,
+        )
 
         if not skip_portfolio:
             # Delete the portfolios at the end of the test

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1209,7 +1209,7 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 1)
 
-        # Assert that the ApiError thrown by LUSID is what is expected, given the input data
+        # Assert that the ApiError thrown by LUSID is what is expected, given the input data 
         self.assertEqual(
             json.loads(holding_responses["holdings"]["errors"][0].body)["name"],
             error_name,

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1167,6 +1167,7 @@ class CocoonTestsHoldings(unittest.TestCase):
         sub_holding_key_scope = None
         return_unmatched_items = True
         holdings_adjustment_only = False
+        failed_unmatched_items_check = ["Please resolve all upload errors to check for unmatched items."]
 
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
 
@@ -1216,7 +1217,7 @@ class CocoonTestsHoldings(unittest.TestCase):
         )
 
         # Assert that there is no 'unmatched_item' field if the input data resulted in no successful uploads
-        self.assertEqual(holding_responses["holdings"].get("unmatched_items"), None)
+        self.assertEqual(holding_responses["holdings"].get("unmatched_items"), failed_unmatched_items_check)
 
         if not skip_portfolio:
             # Delete the portfolios at the end of the test

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -1114,10 +1114,7 @@ class CocoonTestsHoldings(unittest.TestCase):
             scope=portfolio_code_and_scope, code=portfolio_code_and_scope
         )
 
-    @lusid_feature(
-        "T3-43",
-        "T3-44"
-    )
+    @lusid_feature("T3-43", "T3-44")
     @parameterized.expand(
         [
             [
@@ -1133,15 +1130,11 @@ class CocoonTestsHoldings(unittest.TestCase):
                 ["Security Description"],
                 "PortfolioNotFound",
                 True,
-            ]
-        ])
+            ],
+        ]
+    )
     def test_failed_load_from_data_frame_holdings_returns_useful_errors_and_skips_validation_logic(
-            self,
-            _,
-            file_name,
-            sub_holding_keys,
-            error_name,
-            skip_portfolio,
+        self, _, file_name, sub_holding_keys, error_name, skip_portfolio,
     ) -> None:
         """
         Test that a failed holding upload is handled gracefully by the whole load_from_data_frame function.
@@ -1217,7 +1210,10 @@ class CocoonTestsHoldings(unittest.TestCase):
         self.assertEqual(len(holding_responses["holdings"]["errors"]), 1)
 
         # Assert that the ApiError thrown by LUSID is what is expected, given the input data
-        self.assertEqual(json.loads(holding_responses["holdings"]["errors"][0].body)["name"], error_name)
+        self.assertEqual(
+            json.loads(holding_responses["holdings"]["errors"][0].body)["name"],
+            error_name,
+        )
 
         # Assert that there is no 'unmatched_item' field if the input data resulted in no successful uploads
         self.assertEqual(holding_responses["holdings"].get("unmatched_items"), None)


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

If any errors are present in an upload using `load_from_data_frame`, the upload validation logic in `return_unmatched_items` will not be run, even if the flag is passed. All errors will be handled and returned to the user. 
