### PR TITLE
SE-165: More configurable property_columns

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -620,7 +620,9 @@ def _convert_batch_to_models(
          A list of populated LUSID request models
     """
 
-    source_columns = [column.get("target", column.get("source")) for column in property_columns]
+    source_columns = [
+        column.get("target", column.get("source")) for column in property_columns
+    ]
     # Get the data types of the columns to be added as properties
     property_dtypes = data_frame.loc[:, source_columns].dtypes
 

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1429,6 +1429,8 @@ def load_from_data_frame(
         .value
     )
 
+    Validator(property_columns, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+
     property_columns = [
         {"source": column, "target": column} if isinstance(column, str) else column
         for column in property_columns

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -242,6 +242,7 @@ class BatchLoader:
                 code=kwargs["code"],
                 effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
                 adjust_holding_request=holding_batch,
+                _request_timeout=5
             )
 
         return api_factory.build(lusid.api.TransactionPortfoliosApi).set_holdings(
@@ -249,6 +250,7 @@ class BatchLoader:
             code=kwargs["code"],
             effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
             adjust_holding_request=holding_batch,
+            _request_timeout=5
         )
 
     @staticmethod

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1597,7 +1597,7 @@ def load_from_data_frame(
             properties_scope=sub_holding_keys_scope,
             domain="Transaction",
             data_frame=data_frame,
-            property_columns=sub_holding_keys,
+            property_columns=[{"source": key} for key in sub_holding_keys],
         )
 
     # Check for and create missing property definitions for the properties

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -242,7 +242,7 @@ class BatchLoader:
                 code=kwargs["code"],
                 effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
                 adjust_holding_request=holding_batch,
-                _request_timeout=5
+                _request_timeout=5,
             )
 
         return api_factory.build(lusid.api.TransactionPortfoliosApi).set_holdings(
@@ -250,7 +250,7 @@ class BatchLoader:
             code=kwargs["code"],
             effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
             adjust_holding_request=holding_batch,
-            _request_timeout=5
+            _request_timeout=5,
         )
 
     @staticmethod

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1432,16 +1432,20 @@ def load_from_data_frame(
         .value
     )
 
-    property_columns = (Validator(property_columns, "property_columns")
-                        .set_default_value_if_none(default=[])
-                        .value)
+    property_columns = (
+        Validator(property_columns, "property_columns")
+        .set_default_value_if_none(default=[])
+        .value
+    )
 
     property_columns = [
         {"source": column, "target": column} if isinstance(column, str) else column
         for column in property_columns
     ]
 
-    Validator(property_columns, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+    Validator(
+        property_columns, "property_columns"
+    ).check_entries_are_strings_or_dict_containing_key("source")
 
     sub_holding_keys = (
         Validator(sub_holding_keys, "sub_holding_keys")

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1432,17 +1432,16 @@ def load_from_data_frame(
         .value
     )
 
+    property_columns = (Validator(property_columns, "property_columns")
+                        .set_default_value_if_none(default=[])
+                        .value)
+
     property_columns = [
         {"source": column, "target": column} if isinstance(column, str) else column
         for column in property_columns
     ]
 
-    property_columns = (
-        Validator(property_columns, "property_columns")
-        .set_default_value_if_none(default=[])
-        .check_entries_are_strings_or_dict_containing_key("source")
-        .value
-    )
+    Validator(property_columns, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
 
     sub_holding_keys = (
         Validator(sub_holding_keys, "sub_holding_keys")

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1429,7 +1429,9 @@ def load_from_data_frame(
         .value
     )
 
-    Validator(property_columns, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+    Validator(
+        property_columns, "property_columns"
+    ).check_entries_are_strings_or_dict_containing_key("source")
 
     property_columns = [
         {"source": column, "target": column} if isinstance(column, str) else column

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -580,7 +580,7 @@ def _convert_batch_to_models(
     data_frame: pd.DataFrame,
     mapping_required: dict,
     mapping_optional: dict,
-    property_columns: List[dict],
+    property_columns: list,
     properties_scope: str,
     instrument_identifier_mapping: dict,
     file_type: str,
@@ -600,7 +600,7 @@ def _convert_batch_to_models(
         The required mapping
     mapping_optional : dict
         The optional mapping
-    property_columns : List[dict]
+    property_columns : list
         The property columns to add as property values
     properties_scope : str
         The scope to add the property values in
@@ -717,7 +717,7 @@ async def _construct_batches(
     data_frame: pd.DataFrame,
     mapping_required: dict,
     mapping_optional: dict,
-    property_columns: List[dict],
+    property_columns: list,
     properties_scope: str,
     instrument_identifier_mapping: dict,
     batch_size: int,

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -874,17 +874,22 @@ async def _construct_batches(
 
     logging.debug("Created sync batches: ")
     logging.debug(
-        f"Number of batches: {len(sync_batches)}, " +
-        f"Number of items in batches: {sum([len(sync_batch['async_batches']) for sync_batch in sync_batches])}"
+        f"Number of batches: {len(sync_batches)}, "
+        + f"Number of items in batches: {sum([len(sync_batch['async_batches']) for sync_batch in sync_batches])}"
     )
 
     async def gather_func():
         # Schedule three calls *concurrently*:
-        requests = [(async_batch, code, effective_at)
-                    for sync_batch in sync_batches
-                    for async_batch, code, effective_at in
-                    zip(sync_batch["async_batches"], sync_batch["codes"], sync_batch["effective_at"], )
-                    if not async_batch.empty]
+        requests = [
+            (async_batch, code, effective_at)
+            for sync_batch in sync_batches
+            for async_batch, code, effective_at in zip(
+                sync_batch["async_batches"],
+                sync_batch["codes"],
+                sync_batch["effective_at"],
+            )
+            if not async_batch.empty
+        ]
 
         return await asyncio.gather(
             *[

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -2,6 +2,9 @@ import asyncio
 import lusid
 import pandas as pd
 import json
+
+from typing import List
+
 from lusidtools import cocoon
 from lusidtools.cocoon.async_tools import run_in_executor, ThreadPool
 from lusidtools.cocoon.dateorcutlabel import DateOrCutLabel
@@ -577,7 +580,7 @@ def _convert_batch_to_models(
     data_frame: pd.DataFrame,
     mapping_required: dict,
     mapping_optional: dict,
-    property_columns: list,
+    property_columns: List[dict],
     properties_scope: str,
     instrument_identifier_mapping: dict,
     file_type: str,
@@ -597,7 +600,7 @@ def _convert_batch_to_models(
         The required mapping
     mapping_optional : dict
         The optional mapping
-    property_columns : list
+    property_columns : List[dict]
         The property columns to add as property values
     properties_scope : str
         The scope to add the property values in

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1432,25 +1432,20 @@ def load_from_data_frame(
         .value
     )
 
-    Validator(
-        property_columns, "property_columns"
-    ).check_entries_are_strings_or_dict_containing_key("source")
-
     property_columns = [
         {"source": column, "target": column} if isinstance(column, str) else column
         for column in property_columns
     ]
 
-    property_columns = (
-        Validator(property_columns, "property_columns")
-        .set_default_value_if_none(default=[])
-        .value
-    )
+    property_columns = (Validator(property_columns, "property_columns")
+                        .set_default_value_if_none(default=[])
+                        .check_entries_are_strings_or_dict_containing_key("source")
+                        .value)
 
     sub_holding_keys = (
         Validator(sub_holding_keys, "sub_holding_keys")
-        .set_default_value_if_none(default=[])
-        .value
+            .set_default_value_if_none(default=[])
+            .value
     )
 
     batch_size = (

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1437,15 +1437,17 @@ def load_from_data_frame(
         for column in property_columns
     ]
 
-    property_columns = (Validator(property_columns, "property_columns")
-                        .set_default_value_if_none(default=[])
-                        .check_entries_are_strings_or_dict_containing_key("source")
-                        .value)
+    property_columns = (
+        Validator(property_columns, "property_columns")
+        .set_default_value_if_none(default=[])
+        .check_entries_are_strings_or_dict_containing_key("source")
+        .value
+    )
 
     sub_holding_keys = (
         Validator(sub_holding_keys, "sub_holding_keys")
-            .set_default_value_if_none(default=[])
-            .value
+        .set_default_value_if_none(default=[])
+        .value
     )
 
     batch_size = (

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -717,7 +717,7 @@ async def _construct_batches(
     data_frame: pd.DataFrame,
     mapping_required: dict,
     mapping_optional: dict,
-    property_columns: list,
+    property_columns: List[dict],
     properties_scope: str,
     instrument_identifier_mapping: dict,
     batch_size: int,

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -68,7 +68,8 @@ def check_property_definitions_exist_in_scope(
     scope: str,
     domain: str,
     data_frame: pd.DataFrame,
-    property_columns: list,
+    target_columns: list,
+    column_to_scope: dict
 ):
     """
     This function identifiers which property definitions are missing from LUSID
@@ -83,9 +84,10 @@ def check_property_definitions_exist_in_scope(
         The domain to check for property definitions in
     data_frame : pd.DataFrame
         The dataframe to check properties for
-    property_columns : list[str]
+    target_columns : list[str]
         The columns to add properties for
-
+    column_to_scope : dict[str:str]
+        Column name to scope
     Returns
     -------
     missing_property_columns :  list[str]
@@ -101,13 +103,14 @@ def check_property_definitions_exist_in_scope(
 
     # Iterate over the column names
     column_property_mapping = {}
+
     for column_name, data_type in data_frame.loc[
-        :, property_columns
+        :, target_columns
     ].dtypes.iteritems():
 
         # Create the property key
         property_key = (
-            f"{domain}/{scope}/{cocoon.utilities.make_code_lusid_friendly(column_name)}"
+            f"{domain}/{column_to_scope[column_name]}/{cocoon.utilities.make_code_lusid_friendly(column_name)}"
         )
 
         column_property_mapping[property_key] = column_name
@@ -154,6 +157,7 @@ def create_property_definitions_from_file(
     domain: str,
     data_frame: pd.DataFrame,
     missing_property_columns: list,
+    column_to_scope: dict
 ):
     """
     Creates the property definitions for all the columns in a file
@@ -170,6 +174,8 @@ def create_property_definitions_from_file(
         The dataframe dtypes to add definitions for
     missing_property_columns : list[str]
         The columns that property defintions are missing for
+    column_to_scope : dict[str:str]
+        Column name to scope
 
     Returns
     -------
@@ -216,7 +222,7 @@ def create_property_definitions_from_file(
         # Create a request to define the property, assumes value_required is false for all
         property_request = lusid.models.CreatePropertyDefinitionRequest(
             domain=domain,
-            scope=scope,
+            scope=column_to_scope[column_name],
             code=lusid_friendly_code,
             value_required=False,
             display_name=column_name,
@@ -254,6 +260,21 @@ def create_missing_property_definitions_from_file(
     # If there are property columns
     if len(property_columns) > 0 and domain is not None:
 
+        source_columns = [column["source"] for column in property_columns]
+        source_to_target = {
+            column1["source"]: column1.get("target", column1.get("source"))
+            for column1 in property_columns
+        }
+
+        for column in source_columns:
+            data_frame.loc[:, source_to_target[column]] = data_frame[column]
+
+        target_columns = [column.get("target", column.get("source")) for column in property_columns]
+        column_to_scope = {
+            column.get("target", column.get("source")): column.get("scope", properties_scope)
+            for column in property_columns
+        }
+
         # Identify which property definitions are missing
         (
             missing_property_columns,
@@ -263,7 +284,8 @@ def create_missing_property_definitions_from_file(
             scope=properties_scope,
             domain=domain,
             data_frame=data_frame,
-            property_columns=property_columns,
+            target_columns=target_columns,
+            column_to_scope=column_to_scope
         )
 
         logging.info(
@@ -286,6 +308,7 @@ def create_missing_property_definitions_from_file(
                 domain=domain,
                 data_frame=data_frame,
                 missing_property_columns=missing_property_columns,
+                column_to_scope=column_to_scope
             )
 
     return data_frame

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -149,7 +149,6 @@ def check_property_definitions_exist_in_scope(
 @checkargs
 def create_property_definitions_from_file(
     api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
     domain: str,
     data_frame: pd.DataFrame,
     missing_property_columns: list,
@@ -162,8 +161,6 @@ def create_property_definitions_from_file(
     ----------
     api_factory : lusid.utilities.ApiClientFactory
         The ApiFactory to use
-    scope : str
-        The scope to create the property definitions in
     domain : domain
         The domain to create the property definitions in
     data_frame : pd.Series
@@ -304,7 +301,6 @@ def create_missing_property_definitions_from_file(
                 data_frame,
             ) = cocoon.properties.create_property_definitions_from_file(
                 api_factory=api_factory,
-                scope=properties_scope,
                 domain=domain,
                 data_frame=data_frame,
                 missing_property_columns=missing_property_columns,

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -69,7 +69,7 @@ def check_property_definitions_exist_in_scope(
     domain: str,
     data_frame: pd.DataFrame,
     target_columns: list,
-    column_to_scope: dict
+    column_to_scope: dict,
 ):
     """
     This function identifiers which property definitions are missing from LUSID
@@ -104,14 +104,10 @@ def check_property_definitions_exist_in_scope(
     # Iterate over the column names
     column_property_mapping = {}
 
-    for column_name, data_type in data_frame.loc[
-        :, target_columns
-    ].dtypes.iteritems():
+    for column_name, data_type in data_frame.loc[:, target_columns].dtypes.iteritems():
 
         # Create the property key
-        property_key = (
-            f"{domain}/{column_to_scope[column_name]}/{cocoon.utilities.make_code_lusid_friendly(column_name)}"
-        )
+        property_key = f"{domain}/{column_to_scope[column_name]}/{cocoon.utilities.make_code_lusid_friendly(column_name)}"
 
         column_property_mapping[property_key] = column_name
 
@@ -157,7 +153,7 @@ def create_property_definitions_from_file(
     domain: str,
     data_frame: pd.DataFrame,
     missing_property_columns: list,
-    column_to_scope: dict
+    column_to_scope: dict,
 ):
     """
     Creates the property definitions for all the columns in a file
@@ -269,9 +265,13 @@ def create_missing_property_definitions_from_file(
         for column in source_columns:
             data_frame.loc[:, source_to_target[column]] = data_frame[column]
 
-        target_columns = [column.get("target", column.get("source")) for column in property_columns]
+        target_columns = [
+            column.get("target", column.get("source")) for column in property_columns
+        ]
         column_to_scope = {
-            column.get("target", column.get("source")): column.get("scope", properties_scope)
+            column.get("target", column.get("source")): column.get(
+                "scope", properties_scope
+            )
             for column in property_columns
         }
 
@@ -285,7 +285,7 @@ def create_missing_property_definitions_from_file(
             domain=domain,
             data_frame=data_frame,
             target_columns=target_columns,
-            column_to_scope=column_to_scope
+            column_to_scope=column_to_scope,
         )
 
         logging.info(
@@ -308,7 +308,7 @@ def create_missing_property_definitions_from_file(
                 domain=domain,
                 data_frame=data_frame,
                 missing_property_columns=missing_property_columns,
-                column_to_scope=column_to_scope
+                column_to_scope=column_to_scope,
             )
 
     return data_frame

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -67,7 +67,6 @@ def check_property_definitions_exist_in_scope_single(
 @checkargs
 def check_property_definitions_exist_in_scope(
     api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
     domain: str,
     data_frame: pd.DataFrame,
     target_columns: list,
@@ -80,8 +79,6 @@ def check_property_definitions_exist_in_scope(
     ----------
     api_factory :   lusid.utilities.ApiClientFactory
         The Api Factory to use
-    scope : str
-        The scope to check for property definitions in
     domain : str
         The domain to check for property definitions in
     data_frame : pd.DataFrame
@@ -280,7 +277,6 @@ def create_missing_property_definitions_from_file(
             data_frame,
         ) = cocoon.properties.check_property_definitions_exist_in_scope(
             api_factory=api_factory,
-            scope=properties_scope,
             domain=domain,
             data_frame=data_frame,
             target_columns=target_columns,

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -246,7 +246,7 @@ def create_missing_property_definitions_from_file(
     api_factory: lusid.utilities.ApiClientFactory,
     properties_scope: str,
     data_frame: pd.DataFrame,
-    property_columns: List[dict],
+    property_columns: list,
     domain: str,
 ):
     # If there are property columns

--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from lusidtools.cocoon.utilities import checkargs
 from lusidtools import cocoon
 import lusid
@@ -247,7 +249,7 @@ def create_missing_property_definitions_from_file(
     api_factory: lusid.utilities.ApiClientFactory,
     properties_scope: str,
     data_frame: pd.DataFrame,
-    property_columns: list,
+    property_columns: List[dict],
     domain: str,
 ):
     # If there are property columns

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -216,5 +216,7 @@ class Validator:
     def check_entries_are_strings_or_dict_containing_key(self, expected_key):
         for item in self.value:
             if isinstance(item, dict) and expected_key not in item:
-                raise ValueError(f"The value {self.value} provided in {self.value_name} is invalid. "
-                                 f"{item} does not contain the mandatory 'source' key.")
+                raise ValueError(
+                    f"The value {self.value} provided in {self.value_name} is invalid. "
+                    f"{item} does not contain the mandatory 'source' key."
+                )

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -223,10 +223,14 @@ class Validator:
 
             if isinstance(item, dict):
                 if expected_key not in item:
-                    missing_items.append(f"{item} does not contain the mandatory 'source' key")
+                    missing_items.append(
+                        f"{item} does not contain the mandatory 'source' key"
+                    )
                     continue
                 if not isinstance(item[expected_key], str):
-                    missing_items.append(f"{item[expected_key]} in {item} is not a string")
+                    missing_items.append(
+                        f"{item[expected_key]} in {item} is not a string"
+                    )
                     continue
 
         if len(missing_items) > 0:

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -216,8 +216,10 @@ class Validator:
     def check_entries_are_strings_or_dict_containing_key(self, expected_key):
         for item in self.value:
             if not (isinstance(item, dict) or isinstance(item, str)):
-                raise ValueError(f"The value {self.value} provided in {self.value_name} is invalid. "
-                                 f"{item} is not a string or dictionary.")
+                raise ValueError(
+                    f"The value {self.value} provided in {self.value_name} is invalid. "
+                    f"{item} is not a string or dictionary."
+                )
 
             if isinstance(item, dict) and expected_key not in item:
                 raise ValueError(

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -237,3 +237,5 @@ class Validator:
             raise ValueError(
                 f"The value {self.value} provided in {self.value_name} is invalid. {', '.join(missing_items)}."
             )
+
+        return self

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -214,15 +214,22 @@ class Validator:
                 raise ValueError(err)
 
     def check_entries_are_strings_or_dict_containing_key(self, expected_key):
+        missing_items = []
+
         for item in self.value:
             if not (isinstance(item, dict) or isinstance(item, str)):
-                raise ValueError(
-                    f"The value {self.value} provided in {self.value_name} is invalid. "
-                    f"{item} is not a string or dictionary."
-                )
+                missing_items.append(f"{item} is not a string or dictionary")
+                continue
 
-            if isinstance(item, dict) and expected_key not in item:
-                raise ValueError(
-                    f"The value {self.value} provided in {self.value_name} is invalid. "
-                    f"{item} does not contain the mandatory 'source' key."
-                )
+            if isinstance(item, dict):
+                if expected_key not in item:
+                    missing_items.append(f"{item} does not contain the mandatory 'source' key")
+                    continue
+                if not isinstance(item[expected_key], str):
+                    missing_items.append(f"{item[expected_key]} in {item} is not a string")
+                    continue
+
+        if len(missing_items) > 0:
+            raise ValueError(
+                f"The value {self.value} provided in {self.value_name} is invalid. {', '.join(missing_items)}."
+            )

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -215,6 +215,10 @@ class Validator:
 
     def check_entries_are_strings_or_dict_containing_key(self, expected_key):
         for item in self.value:
+            if not (isinstance(item, dict) or isinstance(item, str)):
+                raise ValueError(f"The value {self.value} provided in {self.value_name} is invalid. "
+                                 f"{item} is not a string or dictionary.")
+
             if isinstance(item, dict) and expected_key not in item:
                 raise ValueError(
                     f"The value {self.value} provided in {self.value_name} is invalid. "

--- a/lusidtools/cocoon/validator.py
+++ b/lusidtools/cocoon/validator.py
@@ -212,3 +212,9 @@ class Validator:
                          "column" and "default"."""
                 logging.error(err)
                 raise ValueError(err)
+
+    def check_entries_are_strings_or_dict_containing_key(self, expected_key):
+        for item in self.value:
+            if isinstance(item, dict) and expected_key not in item:
+                raise ValueError(f"The value {self.value} provided in {self.value_name} is invalid. "
+                                 f"{item} does not contain the mandatory 'source' key.")

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -750,7 +750,7 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         self.assertGreater(len(responses["holdings"]["success"]), 0)
 
-        self.assertEqual(len(responses["holdings"]["errors"]), 0)
+        self.assertEqual(len(responses["holdings"]["errors"]), 0, responses["holdings"]["errors"])
 
         # Assert that by default no unmatched_identifiers are returned in the response
         self.assertFalse(responses["holdings"].get("unmatched_identifiers", False))

--- a/tests/integration/cocoon/test_cocoon_holdings.py
+++ b/tests/integration/cocoon/test_cocoon_holdings.py
@@ -750,7 +750,9 @@ class CocoonTestsHoldings(unittest.TestCase):
 
         self.assertGreater(len(responses["holdings"]["success"]), 0)
 
-        self.assertEqual(len(responses["holdings"]["errors"]), 0, responses["holdings"]["errors"])
+        self.assertEqual(
+            len(responses["holdings"]["errors"]), 0, responses["holdings"]["errors"]
+        )
 
         # Assert that by default no unmatched_identifiers are returned in the response
         self.assertFalse(responses["holdings"].get("unmatched_identifiers", False))

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -511,7 +511,23 @@ class CocoonTestsPortfolios(unittest.TestCase):
             response.key,
         )
 
-    def test_invalid_properties(self) -> None:
+    @parameterized.expand(
+        [
+            [
+                "Invalid dictionary",
+                [{"foo": "bar"}, "abc"],
+                "The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
+                "{'foo': 'bar'} does not contain the mandatory 'source' key."
+            ],
+            [
+                "Non string or dictionary",
+                [1],
+                "The value [1] provided in property_columns is invalid. "
+                "1 is not a string or dictionary."
+            ],
+        ]
+    )
+    def test_invalid_properties(self, _, property_columns, expected_error_message) -> None:
         with self.assertRaises(ValueError) as context:
             cocoon.cocoon.load_from_data_frame(
                 api_factory=self.api_factory,
@@ -521,12 +537,9 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 mapping_optional={},
                 file_type="portfolios",
                 identifier_mapping={},
-                property_columns=[{"foo": "bar"}, "abc"],
+                property_columns=property_columns,
                 properties_scope="bar",
             )
 
-        self.assertEqual(
-            "The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
-            "{'foo': 'bar'} does not contain the mandatory 'source' key.",
-            str(context.exception),
-        )
+        self.assertEqual(expected_error_message, str(context.exception))
+

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -393,12 +393,14 @@ class CocoonTestsPortfolios(unittest.TestCase):
         )
 
         for property_column in property_columns:
-            response = self.api_factory.build(lusid.api.PropertyDefinitionsApi).get_property_definition(
-                domain="Portfolio",
-                scope=properties_scope,
-                code=property_column,
+            response = self.api_factory.build(
+                lusid.api.PropertyDefinitionsApi
+            ).get_property_definition(
+                domain="Portfolio", scope=properties_scope, code=property_column,
             )
-            self.assertEqual(f"Portfolio/{properties_scope}/{property_column}", response.key)
+            self.assertEqual(
+                f"Portfolio/{properties_scope}/{property_column}", response.key
+            )
 
     @parameterized.expand(
         [
@@ -417,7 +419,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 {"source": "base_currency"},
                 "operations0011",
                 "operations0011",
-                "base_currency"
+                "base_currency",
             ],
             [
                 "Source and target",
@@ -434,7 +436,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 {"source": "base_currency", "target": "base_currency2"},
                 "operations0011",
                 "operations0011",
-                "base_currency2"
+                "base_currency2",
             ],
             [
                 "Scope",
@@ -451,8 +453,8 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 {"source": "base_currency", "target": "base_currency2", "scope": "foo"},
                 "operations0011",
                 "foo",
-                "base_currency2"
-            ]
+                "base_currency2",
+            ],
         ]
     )
     def test_properties_dicts(
@@ -466,7 +468,7 @@ class CocoonTestsPortfolios(unittest.TestCase):
         property_column,
         properties_scope,
         expected_property_scope,
-        expected_property_code
+        expected_property_code,
     ) -> None:
         """
         Test that portfolios can be loaded successfully
@@ -495,9 +497,14 @@ class CocoonTestsPortfolios(unittest.TestCase):
             properties_scope=properties_scope,
         )
 
-        response = self.api_factory.build(lusid.api.PropertyDefinitionsApi).get_property_definition(
+        response = self.api_factory.build(
+            lusid.api.PropertyDefinitionsApi
+        ).get_property_definition(
             domain="Portfolio",
             scope=expected_property_scope,
             code=expected_property_code,
         )
-        self.assertEqual(f"Portfolio/{expected_property_scope}/{expected_property_code}", response.key)
+        self.assertEqual(
+            f"Portfolio/{expected_property_scope}/{expected_property_code}",
+            response.key,
+        )

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -515,8 +515,8 @@ class CocoonTestsPortfolios(unittest.TestCase):
         [
             [
                 "Invalid dictionary",
-                [{"foo": "bar"}, "abc"],
-                "The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
+                [{"foo": "bar"}],
+                "The value [{'foo': 'bar'}] provided in property_columns is invalid. "
                 "{'foo': 'bar'} does not contain the mandatory 'source' key.",
             ],
             [

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -1,5 +1,7 @@
 import unittest
 from pathlib import Path
+
+import pandas
 import pandas as pd
 import lusid
 from lusidfeature import lusid_feature
@@ -508,3 +510,22 @@ class CocoonTestsPortfolios(unittest.TestCase):
             f"Portfolio/{expected_property_scope}/{expected_property_code}",
             response.key,
         )
+
+    def test_invalid_properties(self) -> None:
+        with self.assertRaises(ValueError) as context:
+            cocoon.cocoon.load_from_data_frame(
+                api_factory=self.api_factory,
+                scope="foo",
+                data_frame=pandas.DataFrame(),
+                mapping_required={},
+                mapping_optional={},
+                file_type="portfolios",
+                identifier_mapping={},
+                property_columns=[{"foo": "bar"}, "abc"],
+                properties_scope="bar",
+            )
+
+        self.assertEqual("The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
+                         "{'foo': 'bar'} does not contain the mandatory 'source' key.",
+                         str(context.exception))
+

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -517,17 +517,19 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 "Invalid dictionary",
                 [{"foo": "bar"}, "abc"],
                 "The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
-                "{'foo': 'bar'} does not contain the mandatory 'source' key."
+                "{'foo': 'bar'} does not contain the mandatory 'source' key.",
             ],
             [
                 "Non string or dictionary",
                 [1],
                 "The value [1] provided in property_columns is invalid. "
-                "1 is not a string or dictionary."
+                "1 is not a string or dictionary.",
             ],
         ]
     )
-    def test_invalid_properties(self, _, property_columns, expected_error_message) -> None:
+    def test_invalid_properties(
+        self, _, property_columns, expected_error_message
+    ) -> None:
         with self.assertRaises(ValueError) as context:
             cocoon.cocoon.load_from_data_frame(
                 api_factory=self.api_factory,
@@ -542,4 +544,3 @@ class CocoonTestsPortfolios(unittest.TestCase):
             )
 
         self.assertEqual(expected_error_message, str(context.exception))
-

--- a/tests/integration/cocoon/test_cocoon_portfolios.py
+++ b/tests/integration/cocoon/test_cocoon_portfolios.py
@@ -525,7 +525,8 @@ class CocoonTestsPortfolios(unittest.TestCase):
                 properties_scope="bar",
             )
 
-        self.assertEqual("The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
-                         "{'foo': 'bar'} does not contain the mandatory 'source' key.",
-                         str(context.exception))
-
+        self.assertEqual(
+            "The value [{'foo': 'bar'}, 'abc'] provided in property_columns is invalid. "
+            "{'foo': 'bar'} does not contain the mandatory 'source' key.",
+            str(context.exception),
+        )

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -313,7 +313,7 @@ class CocoonTestsTransactions(unittest.TestCase):
         self.assertEqual(
             len(responses["transactions"]["errors"]),
             0,
-            responses["transactions"]["errors"],
+            [(error.status, error.reason, error.body) for error in responses["transactions"]["errors"]]
         )
 
         # Assert that by default no unmatched_identifiers are returned in the response

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -310,7 +310,11 @@ class CocoonTestsTransactions(unittest.TestCase):
 
         self.assertGreater(len(responses["transactions"]["success"]), 0)
 
-        self.assertEqual(len(responses["transactions"]["errors"]), 0, responses["transactions"]["errors"])
+        self.assertEqual(
+            len(responses["transactions"]["errors"]),
+            0,
+            responses["transactions"]["errors"],
+        )
 
         # Assert that by default no unmatched_identifiers are returned in the response
         self.assertFalse(responses["transactions"].get("unmatched_identifiers", False))

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -313,7 +313,10 @@ class CocoonTestsTransactions(unittest.TestCase):
         self.assertEqual(
             len(responses["transactions"]["errors"]),
             0,
-            [(error.status, error.reason, error.body) for error in responses["transactions"]["errors"]]
+            [
+                (error.status, error.reason, error.body)
+                for error in responses["transactions"]["errors"]
+            ],
         )
 
         # Assert that by default no unmatched_identifiers are returned in the response

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -310,7 +310,7 @@ class CocoonTestsTransactions(unittest.TestCase):
 
         self.assertGreater(len(responses["transactions"]["success"]), 0)
 
-        self.assertEqual(len(responses["transactions"]["errors"]), 0)
+        self.assertEqual(len(responses["transactions"]["errors"]), 0, responses["transactions"]["errors"])
 
         # Assert that by default no unmatched_identifiers are returned in the response
         self.assertFalse(responses["transactions"].get("unmatched_identifiers", False))

--- a/tests/integration/extract/test_group_holdings.py
+++ b/tests/integration/extract/test_group_holdings.py
@@ -76,7 +76,9 @@ class CocoonTestsExtractGroupHoldings(unittest.TestCase):
             property_columns=[],
             holdings_adjustment_only=True,
         )
-        assert len(response["holdings"]["errors"]) == 0, len(response["holdings"]["errors"])
+        assert len(response["holdings"]["errors"]) == 0, len(
+            response["holdings"]["errors"]
+        )
 
         # Create groups
         response = cocoon.load_from_data_frame(

--- a/tests/integration/extract/test_group_holdings.py
+++ b/tests/integration/extract/test_group_holdings.py
@@ -76,7 +76,7 @@ class CocoonTestsExtractGroupHoldings(unittest.TestCase):
             property_columns=[],
             holdings_adjustment_only=True,
         )
-        assert len(response["holdings"]["errors"]) == 0
+        assert len(response["holdings"]["errors"]) == 0, len(response["holdings"]["errors"])
 
         # Create groups
         response = cocoon.load_from_data_frame(

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -213,7 +213,8 @@ class CocoonPropertiesTests(unittest.TestCase):
             api_factory=self.api_factory,
             domain=domain,
             data_frame=data_frame,
-            property_columns=property_columns,
+            target_columns=property_columns,
+            column_to_scope={column: scope for column in property_columns}
         )
 
         self.assertEqual(first=len(missing_columns), second=len(set(missing_columns)))
@@ -315,6 +316,7 @@ class CocoonPropertiesTests(unittest.TestCase):
             domain=domain,
             data_frame=data_frame,
             missing_property_columns=missing_property_columns,
+            column_to_scope={column: scope for column in missing_property_columns}
         )
 
         self.assertEqual(first=property_key_mapping, second=expected_outcome[0])

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -313,7 +313,6 @@ class CocoonPropertiesTests(unittest.TestCase):
             data_frame_updated,
         ) = cocoon.properties.create_property_definitions_from_file(
             api_factory=self.api_factory,
-            scope=scope,
             domain=domain,
             data_frame=data_frame,
             missing_property_columns=missing_property_columns,

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -211,7 +211,6 @@ class CocoonPropertiesTests(unittest.TestCase):
             updated_data_frame,
         ) = cocoon.properties.check_property_definitions_exist_in_scope(
             api_factory=self.api_factory,
-            scope=scope,
             domain=domain,
             data_frame=data_frame,
             property_columns=property_columns,

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -214,7 +214,7 @@ class CocoonPropertiesTests(unittest.TestCase):
             domain=domain,
             data_frame=data_frame,
             target_columns=property_columns,
-            column_to_scope={column: scope for column in property_columns}
+            column_to_scope={column: scope for column in property_columns},
         )
 
         self.assertEqual(first=len(missing_columns), second=len(set(missing_columns)))
@@ -316,7 +316,7 @@ class CocoonPropertiesTests(unittest.TestCase):
             domain=domain,
             data_frame=data_frame,
             missing_property_columns=missing_property_columns,
-            column_to_scope={column: scope for column in missing_property_columns}
+            column_to_scope={column: scope for column in missing_property_columns},
         )
 
         self.assertEqual(first=property_key_mapping, second=expected_outcome[0])

--- a/tests/unit/cocoon/test_validator.py
+++ b/tests/unit/cocoon/test_validator.py
@@ -341,3 +341,52 @@ class CocoonUtilitiesTests(unittest.TestCase):
             Validator(value, value_name).check_no_intersection_with_list(
                 other_list, list_name
             )
+
+    @parameterized.expand(
+        [
+            [
+                "Dictionary missing 'source' key",
+                [{"foo": "bar"}],
+                "The value [{'foo': 'bar'}] provided in property_columns is invalid.",
+                "{'foo': 'bar'} does not contain the mandatory 'source' key."
+            ],
+            [
+                "Dictionary with 'source' that's not a string",
+                [{"source": 2}],
+                "The value [{'source': 2}] provided in property_columns is invalid.",
+                "2 in {'source': 2} is not a string."
+            ],
+            [
+                "Non string",
+                [1],
+                "The value [1] provided in property_columns is invalid",
+                "1 is not a string or dictionary."
+            ],
+            [
+                "Multiple errors",
+                [1, {"foo": "bar"}, {"source": [5]}],
+                "The value [1, {'foo': 'bar'}, {'source': [5]}] provided in property_columns is invalid",
+                "1 is not a string or dictionary, " +
+                "{'foo': 'bar'} does not contain the mandatory 'source' key, " +
+                "[5] in {'source': [5]} is not a string."
+            ]
+        ]
+    )
+    def test_check_entries_are_strings_or_dict_containing_key_invalid_values(self, _, value,
+                                                                             expected_message_part1,
+                                                                             expected_message_part2):
+        with self.assertRaises(ValueError) as context:
+            Validator(value, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+
+        self.assertTrue(expected_message_part1 in str(context.exception), str(context.exception))
+        self.assertTrue(expected_message_part2 in str(context.exception), str(context.exception))
+
+    @parameterized.expand(
+        [
+            ["Dictionary with 'source'", [{"source": "foo"}]],
+            ["String", ["foo"]],
+            ["Multiple values", ["foo", {"source": "bar"}]]
+        ]
+    )
+    def test_check_entries_are_strings_or_dict_containing_key_valid_values(self, _, value):
+        Validator(value, "property_columns").check_entries_are_strings_or_dict_containing_key("source")

--- a/tests/unit/cocoon/test_validator.py
+++ b/tests/unit/cocoon/test_validator.py
@@ -348,45 +348,55 @@ class CocoonUtilitiesTests(unittest.TestCase):
                 "Dictionary missing 'source' key",
                 [{"foo": "bar"}],
                 "The value [{'foo': 'bar'}] provided in property_columns is invalid.",
-                "{'foo': 'bar'} does not contain the mandatory 'source' key."
+                "{'foo': 'bar'} does not contain the mandatory 'source' key.",
             ],
             [
                 "Dictionary with 'source' that's not a string",
                 [{"source": 2}],
                 "The value [{'source': 2}] provided in property_columns is invalid.",
-                "2 in {'source': 2} is not a string."
+                "2 in {'source': 2} is not a string.",
             ],
             [
                 "Non string",
                 [1],
                 "The value [1] provided in property_columns is invalid",
-                "1 is not a string or dictionary."
+                "1 is not a string or dictionary.",
             ],
             [
                 "Multiple errors",
                 [1, {"foo": "bar"}, {"source": [5]}],
                 "The value [1, {'foo': 'bar'}, {'source': [5]}] provided in property_columns is invalid",
-                "1 is not a string or dictionary, " +
-                "{'foo': 'bar'} does not contain the mandatory 'source' key, " +
-                "[5] in {'source': [5]} is not a string."
-            ]
+                "1 is not a string or dictionary, "
+                + "{'foo': 'bar'} does not contain the mandatory 'source' key, "
+                + "[5] in {'source': [5]} is not a string.",
+            ],
         ]
     )
-    def test_check_entries_are_strings_or_dict_containing_key_invalid_values(self, _, value,
-                                                                             expected_message_part1,
-                                                                             expected_message_part2):
+    def test_check_entries_are_strings_or_dict_containing_key_invalid_values(
+        self, _, value, expected_message_part1, expected_message_part2
+    ):
         with self.assertRaises(ValueError) as context:
-            Validator(value, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+            Validator(
+                value, "property_columns"
+            ).check_entries_are_strings_or_dict_containing_key("source")
 
-        self.assertTrue(expected_message_part1 in str(context.exception), str(context.exception))
-        self.assertTrue(expected_message_part2 in str(context.exception), str(context.exception))
+        self.assertTrue(
+            expected_message_part1 in str(context.exception), str(context.exception)
+        )
+        self.assertTrue(
+            expected_message_part2 in str(context.exception), str(context.exception)
+        )
 
     @parameterized.expand(
         [
             ["Dictionary with 'source'", [{"source": "foo"}]],
             ["String", ["foo"]],
-            ["Multiple values", ["foo", {"source": "bar"}]]
+            ["Multiple values", ["foo", {"source": "bar"}]],
         ]
     )
-    def test_check_entries_are_strings_or_dict_containing_key_valid_values(self, _, value):
-        Validator(value, "property_columns").check_entries_are_strings_or_dict_containing_key("source")
+    def test_check_entries_are_strings_or_dict_containing_key_valid_values(
+        self, _, value
+    ):
+        Validator(
+            value, "property_columns"
+        ).check_entries_are_strings_or_dict_containing_key("source")


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Basically lets you pass in property columns like this:

`"column1"`
or
`{"source": "column1", "target": "myAwesomeColumn", "scope": "mySuperScope"}`

You can mix dictionaries and strings in the same list.
If you don’t provide target it will use `source` as property code. If you don’t provide scope it will use `properties_scope` as the scope.
