### PR TITLE
Origin/feature/SE-1657 - Make error handling of missing property definitions more explicit

### DIFF
--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -3,6 +3,7 @@ from lusidtools import cocoon
 import lusid
 import pandas as pd
 import logging
+from http import HTTPStatus
 
 # Map Numpy data types to LUSID data types
 global_constants = {
@@ -52,8 +53,11 @@ def check_property_definitions_exist_in_scope_single(
         exists = True
         data_type = response.data_type_id.code
 
-    except lusid.exceptions.ApiException:
-        exists = False
+    except lusid.exceptions.ApiException as ex:
+        if ex.status == HTTPStatus.NOT_FOUND:
+            exists = False
+        else:
+            raise
 
     return exists, data_type
 

--- a/tests/unit/cocoon/test_properties.py
+++ b/tests/unit/cocoon/test_properties.py
@@ -6,6 +6,7 @@ import lusidtools.cocoon as cocoon
 import pandas as pd
 import numpy as np
 from lusidtools import logger
+from http import HTTPStatus
 
 
 class CocoonPropertiesTests(unittest.TestCase):
@@ -84,14 +85,22 @@ class CocoonPropertiesTests(unittest.TestCase):
                     ),
                 }
 
+                forbidden_property_keys = {
+                    "Instrument/default/Forbidden": lusid.models.ResourceId(
+                        scope="system", code="string"
+                    )
+                }
+
                 # If the property exists return the defintion, else raise an exception
                 if property_key in list(property_keys_in_existance.keys()):
                     return lusid.models.PropertyDefinition(
                         key=property_key,
                         data_type_id=property_keys_in_existance[property_key],
                     )
+                elif property_key in list(forbidden_property_keys.keys()):
+                    raise lusid.exceptions.ApiException(HTTPStatus.FORBIDDEN)
                 else:
-                    raise lusid.exceptions.ApiException
+                    raise lusid.exceptions.ApiException(HTTPStatus.NOT_FOUND)
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -107,10 +116,11 @@ class CocoonPropertiesTests(unittest.TestCase):
             ["Transaction/default/TradeToPortfolioRate", [True, "number"]],
             ["Transaction/Operations/Strategy", [True, "string"]],
             ["Holding/Operations/Currency", [True, "currency"]],
+            ["Instrument/default/Forbidden", [True, "currency"], True],
         ]
     )
     def test_check_property_definitions_exist_in_scope_single(
-        self, property_key, expected_outcomes
+        self, property_key, expected_outcomes, throws_exception=False
     ) -> None:
         """
         Tests that checking for a property definition in a single scope works as expected. The call to LUSID
@@ -121,16 +131,18 @@ class CocoonPropertiesTests(unittest.TestCase):
 
         :return: None
         """
+        try:
+            (
+                property_existence,
+                property_type,
+            ) = cocoon.properties.check_property_definitions_exist_in_scope_single(
+                api_factory=self.api_factory, property_key=property_key
+            )
 
-        (
-            property_existence,
-            property_type,
-        ) = cocoon.properties.check_property_definitions_exist_in_scope_single(
-            api_factory=self.api_factory, property_key=property_key
-        )
-
-        self.assertEqual(property_existence, expected_outcomes[0])
-        self.assertEqual(property_type, expected_outcomes[1])
+            self.assertEqual(property_existence, expected_outcomes[0])
+            self.assertEqual(property_type, expected_outcomes[1])
+        except:
+            self.assertEqual(throws_exception, True)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

When checking if a property exists on a given instrument/transaction we need to be more explicit when handling errors. If a 404 is thrown, we will say that the property doesn't exist. If a different status code is returned (ex: Forbidden, Unauthorized, etc), we will continue to throw the exception up the stack.
