### PR TITLE
SE-1923 Remove arbitrary request timeout included in err

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -241,16 +241,14 @@ class BatchLoader:
                 scope=kwargs["scope"],
                 code=kwargs["code"],
                 effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
-                adjust_holding_request=holding_batch,
-                _request_timeout=5,
+                adjust_holding_request=holding_batch
             )
 
         return api_factory.build(lusid.api.TransactionPortfoliosApi).set_holdings(
             scope=kwargs["scope"],
             code=kwargs["code"],
             effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
-            adjust_holding_request=holding_batch,
-            _request_timeout=5,
+            adjust_holding_request=holding_batch
         )
 
     @staticmethod

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -241,14 +241,14 @@ class BatchLoader:
                 scope=kwargs["scope"],
                 code=kwargs["code"],
                 effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
-                adjust_holding_request=holding_batch
+                adjust_holding_request=holding_batch,
             )
 
         return api_factory.build(lusid.api.TransactionPortfoliosApi).set_holdings(
             scope=kwargs["scope"],
             code=kwargs["code"],
             effective_at=str(DateOrCutLabel(kwargs["effective_at"])),
-            adjust_holding_request=holding_batch
+            adjust_holding_request=holding_batch,
         )
 
     @staticmethod


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

In the merge request to add support for [configurable property columns](https://github.com/finbourne/lusid-python-tools/pull/225) we added an arbitrary 5 second timeout on calls to `SetHoldings` and `AdjustHoldings`.

These were included in error and need to be removed to allow for calls which take 5 seconds or longer to be successful. 
