### PR TITLE
Feature/SENG-37: Update lusid sdk version and fix tests

### DIFF
--- a/lusidtools/lpt/dfq.py
+++ b/lusidtools/lpt/dfq.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 import pandas as pd
+import numpy as np
 
 
 def parse(with_inputs=True, args=None):
@@ -191,6 +192,9 @@ def apply_args(args, given_df):
                         v = int(v[:-7])
                         dflt = 0
                     elif df[col].dtype == int:
+                        v = int(v)
+                        dflt = 0
+                    elif df[col].dtype == np.int64:
                         v = int(v)
                         dflt = 0
                     elif df[col].dtype == float:

--- a/lusidtools/lpt/qry_properties.py
+++ b/lusidtools/lpt/qry_properties.py
@@ -48,4 +48,5 @@ def process_args(api, args):
 
 # Standalone tool
 def main(parse=parse, display_df=lpt.display_df):
-    return lpt.standard_flow(parse, lse.connect, process_args, display_df)
+    raise NotImplementedError("Jira: SENG-40")
+    # return lpt.standard_flow(parse, lse.connect, process_args, display_df)

--- a/lusidtools/lpt/qry_properties.py
+++ b/lusidtools/lpt/qry_properties.py
@@ -5,8 +5,8 @@ from lusidtools.lpt import lpt
 
 # Jira: SENG-40 - Property search was deprecated and this query requires updating
 # Uncomment tooltips when fixed
-#TOOLNAME = "props"
-#TOOLTIP = "Query property definitions"
+# TOOLNAME = "props"
+# TOOLTIP = "Query property definitions"
 
 
 def parse(extend=None, args=None):
@@ -50,5 +50,7 @@ def process_args(api, args):
 
 # Standalone tool
 def main(parse=parse, display_df=lpt.display_df):
-    raise NotImplementedError("Jira: SENG-40 - Property search was deprecated and this query requires updating")
+    raise NotImplementedError(
+        "Jira: SENG-40 - Property search was deprecated and this query requires updating"
+    )
     # return lpt.standard_flow(parse, lse.connect, process_args, display_df)

--- a/lusidtools/lpt/qry_properties.py
+++ b/lusidtools/lpt/qry_properties.py
@@ -3,8 +3,10 @@ from lusidtools.lpt import lse
 from lusidtools.lpt import stdargs
 from lusidtools.lpt import lpt
 
-TOOLNAME = "props"
-TOOLTIP = "Query property definitions"
+# Jira: SENG-40 - Property search was deprecated and this query requires updating
+# Uncomment tooltips when fixed
+#TOOLNAME = "props"
+#TOOLTIP = "Query property definitions"
 
 
 def parse(extend=None, args=None):
@@ -48,5 +50,5 @@ def process_args(api, args):
 
 # Standalone tool
 def main(parse=parse, display_df=lpt.display_df):
-    raise NotImplementedError("Jira: SENG-40")
+    raise NotImplementedError("Jira: SENG-40 - Property search was deprecated and this query requires updating")
     # return lpt.standard_flow(parse, lse.connect, process_args, display_df)

--- a/lusidtools/lpt/txn_config_yaml.py
+++ b/lusidtools/lpt/txn_config_yaml.py
@@ -385,15 +385,28 @@ class TxnConfigYaml:
     @staticmethod
     def alias_con(loader, node):
         s = loader.construct_sequence(node)
-        return (
-            s[0],
-            s[1],
-            s[4],
-            s[3],
-            s[2],
-            unabbrev(s[5]),
-            (len(s) > 6 and s[6] == "default"),
-        )
+        # If old yaml files are used with only 5 params set for txn type alias (SENG-41)
+        if len(s) == 5:
+            return (
+                s[0],
+                s[1],
+                s[3],
+                s[3],
+                s[2],
+                unabbrev(s[4]),
+                (len(s) > 5 and s[5] == "default"),
+            )
+        # If newer yaml files are used with additional params set for txn type alias (SENG-41)
+        else:
+            return (
+                s[0],
+                s[1],
+                s[4],
+                s[3],
+                s[2],
+                unabbrev(s[5]),
+                (len(s) > 6 and s[6] == "default"),
+            )
 
     # Set up the YAML converter for the SideConfigurationDataRequest (side)
     @staticmethod

--- a/lusidtools/lpt/txn_config_yaml.py
+++ b/lusidtools/lpt/txn_config_yaml.py
@@ -377,6 +377,7 @@ class TxnConfigYaml:
             data.type,
             data.description,
             data.transaction_group,
+            data.source,
             data.transaction_class,
             abbrev(data.transaction_roles),
         ] + (["default"] if data.is_default else [])
@@ -387,10 +388,11 @@ class TxnConfigYaml:
         return (
             s[0],
             s[1],
+            s[4],
             s[3],
             s[2],
-            unabbrev(s[4]),
-            (len(s) > 5 and s[5] == "default"),
+            unabbrev(s[5]),
+            (len(s) > 6 and s[6] == "default"),
         )
 
     # Set up the YAML converter for the SideConfigurationDataRequest (side)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ detect_delimiter==0.1.1
 flatten-json==0.1.7
 IPython==7.19.0
 lusidfeature
-lusid-sdk-preview==0.11.*
+lusid-sdk-preview>=0.11.3681
 pandas>=1.1.4
 PyYAML==5.4
 requests==2.25.0

--- a/tests/integration/cocoon/test_create_transaction_type.py
+++ b/tests/integration/cocoon/test_create_transaction_type.py
@@ -70,8 +70,7 @@ class CocoonTestTransactionTypeUpload(unittest.TestCase):
         ][0]
 
         self.assertEqual(
-            set(new_alias.to_dict().items()),
-            set(self.alias.to_dict().items()),
+            set(new_alias.to_dict().items()), set(self.alias.to_dict().items()),
         )
 
         self.assertEqual(

--- a/tests/integration/cocoon/test_create_transaction_type.py
+++ b/tests/integration/cocoon/test_create_transaction_type.py
@@ -27,6 +27,7 @@ class CocoonTestTransactionTypeUpload(unittest.TestCase):
             description="TESTBUY1",
             transaction_class="TESTBUY1",
             transaction_group="SYSTEM1",
+            source="SYSTEM1",
             transaction_roles="AllRoles",
             is_default=False,
         )

--- a/tests/integration/cocoon/test_create_transaction_type.py
+++ b/tests/integration/cocoon/test_create_transaction_type.py
@@ -61,8 +61,16 @@ class CocoonTestTransactionTypeUpload(unittest.TestCase):
         Verify that the new transaction type is created.
         """
 
+        new_alias = [
+            alias
+            for transaction_grouping in self.response.transaction_configs
+            for alias in transaction_grouping.aliases
+            if (self.alias.type, self.alias.transaction_group)
+            == (alias.type, alias.transaction_group)
+        ][0]
+
         self.assertEqual(
-            set(self.response.transaction_configs[-1].aliases[0].to_dict().items()),
+            set(new_alias.to_dict().items()),
             set(self.alias.to_dict().items()),
         )
 

--- a/tests/integration/cocoon/test_upsert_transaction_type_alias.py
+++ b/tests/integration/cocoon/test_upsert_transaction_type_alias.py
@@ -37,6 +37,7 @@ class CocoonTestTransactionTypeUpload(unittest.TestCase):
                         description="TESTBUY1",
                         transaction_class="TESTBUY1",
                         transaction_group="SYSTEM1",
+                        source="SYSTEM1",
                         transaction_roles="AllRoles",
                         is_default=False,
                     )
@@ -66,6 +67,7 @@ class CocoonTestTransactionTypeUpload(unittest.TestCase):
                         description="TESTSELL1",
                         transaction_class="TESTSELL1",
                         transaction_group="SYSTEM1",
+                        source="SYSTEM1",
                         transaction_roles="AllRoles",
                         is_default=False,
                     )

--- a/tests/integration/commands/test_commands.py
+++ b/tests/integration/commands/test_commands.py
@@ -143,6 +143,7 @@ class CommandsTests(unittest.TestCase):
         )
         self.validate_results_df(result)
 
+    @unittest.skip("Jira: SENG-40")
     def test_get_props(self):
 
         result = get_props.main(

--- a/tests/integration/commands/test_commands.py
+++ b/tests/integration/commands/test_commands.py
@@ -143,7 +143,9 @@ class CommandsTests(unittest.TestCase):
         )
         self.validate_results_df(result)
 
-    @unittest.skip("Jira: SENG-40 - Property search was deprecated and this query requires updating")
+    @unittest.skip(
+        "Jira: SENG-40 - Property search was deprecated and this query requires updating"
+    )
     def test_get_props(self):
 
         result = get_props.main(

--- a/tests/integration/commands/test_commands.py
+++ b/tests/integration/commands/test_commands.py
@@ -143,7 +143,7 @@ class CommandsTests(unittest.TestCase):
         )
         self.validate_results_df(result)
 
-    @unittest.skip("Jira: SENG-40")
+    @unittest.skip("Jira: SENG-40 - Property search was deprecated and this query requires updating")
     def test_get_props(self):
 
         result = get_props.main(


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Tests were failing in part because an outdated lusid-python-sdk was being used. This change includes an update to the requirements file.

A new model for `transaction_configuration_type_alias` included a new parameter (`source`) which was throwing off a number of tests that expected either the old model or one fewer parameter. 

Also fixed two other tests and added a skip flag to the `properties_search` test that needs further investigation. The functionality being tested has been commented out and a Jira has been raised to investigate. 
