### PR TITLE
Ctech 1363 flush transactions can flush for all portfolios in scope

### DIFF
--- a/lusidtools/apps/flush_transactions.py
+++ b/lusidtools/apps/flush_transactions.py
@@ -186,8 +186,9 @@ def get_portfolios_from_group(expanded_group):
     return temp_portfolio_lst
 
 
-def get_transactions_from_portfolio_list(args, portfolio_list, transaction_portfolios_api):
+def get_all_transactions_from_portfolio_list(args, portfolio_list, transaction_portfolios_api):
     """
+    Gets all transactions from the list of portfolio scope and codes that are passed in. Pagination is handled.
 
     Parameters
     ----------
@@ -205,24 +206,22 @@ def get_transactions_from_portfolio_list(args, portfolio_list, transaction_portf
 
     """
     # Get transactions from these portfolios
-    txn_dict = {}
-    for portfolio_scope, portfolio_code in portfolio_list:
-        transaction_lst_single_portfolio = [
+    return {
+        (portfolio_scope, portfolio_code): [
             transaction
-            for page in get_paginated_txns(
+            for page
+            in get_paginated_txns(
                 portfolio_scope,
                 portfolio_code,
                 args.start_date,
                 args.end_date,
                 transaction_portfolios_api,
             )
-            for transaction in page.values
-        ]
-        txn_dict[
-            (portfolio_scope, portfolio_code)
-        ] = transaction_lst_single_portfolio
-
-    return txn_dict
+            for transaction
+            in page.values]
+        for (portfolio_scope, portfolio_code)
+        in portfolio_list
+    }
 
 
 def get_all_txns(args):
@@ -251,7 +250,7 @@ def get_all_txns(args):
         )
         portfolio_lst = get_portfolios_from_group(portfolios_response)
 
-        return get_transactions_from_portfolio_list(args, portfolio_lst, transaction_portfolios_api)
+        return get_all_transactions_from_portfolio_list(args, portfolio_lst, transaction_portfolios_api)
 
     elif args.flush_scope:
         # Get a list of all portfolios in the scope
@@ -263,7 +262,7 @@ def get_all_txns(args):
             portfolios_api.list_portfolios_for_scope(scope=args.scope).values
         ]
 
-        return get_transactions_from_portfolio_list(args, portfolio_lst, transaction_portfolios_api)
+        return get_all_transactions_from_portfolio_list(args, portfolio_lst, transaction_portfolios_api)
 
     else:
         # Return the portfolio and scope passed in

--- a/lusidtools/apps/flush_transactions.py
+++ b/lusidtools/apps/flush_transactions.py
@@ -8,7 +8,7 @@ from lusidtools.logger import LusidLogger
 def parse(extend=None, args=None):
     return (
         stdargs.Parser(
-            "Flush Transactions", ["scope", "portfolio", "date_range", "group"],
+            "Flush Transactions", ["scope", "optional_portfolio", "date_range", "group"],
         )
         .extend(extend)
         .parse(args)

--- a/lusidtools/lpt/stdargs.py
+++ b/lusidtools/lpt/stdargs.py
@@ -63,6 +63,14 @@ class Parser:
                 help="Indicates use of Portfolio Groups",
             )
 
+        if "optional_portfolio" in sections:
+            self.add(
+                "-p",
+                "--portfolio",
+                dest="portfolio",
+                help="Optional Portfolio id"
+            )
+
         self.add(
             "--secrets-file",
             dest="secrets",

--- a/lusidtools/lpt/stdargs.py
+++ b/lusidtools/lpt/stdargs.py
@@ -71,6 +71,14 @@ class Parser:
                 help="Optional Portfolio id"
             )
 
+        if "flush_scope" in sections:
+            self.add(
+                "--flush_scope",
+                dest="flush_scope",
+                action="store_true",
+                help="Flush all transactions in scope"
+            )
+
         self.add(
             "--secrets-file",
             dest="secrets",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ detect_delimiter==0.1.1
 flatten-json==0.1.7
 IPython==7.31.1
 lusidfeature
-lusid-sdk-preview>=0.11.3681
+lusid-sdk-preview>=0.11.4425
 pandas>=1.1.4
 PyYAML==5.4
 requests==2.25.0

--- a/tests/integration/apps/test_command_line_apps.py
+++ b/tests/integration/apps/test_command_line_apps.py
@@ -369,6 +369,7 @@ class AppTests(unittest.TestCase):
                 flush_transactions.parse(
                     args=[
                         "testscope0001",
+                        "-p",
                         "TestFlushPortfolio",
                         "-s",
                         "2020-02-20T00:00:00.0000000+00:00",
@@ -383,6 +384,7 @@ class AppTests(unittest.TestCase):
                 flush_transactions.parse(
                     args=[
                         "testscope0001",
+                        "-p",
                         "TestFlushPortfolio",
                         "-s",
                         "2020-02-18T00:00:00.0000000+00:00",
@@ -397,6 +399,7 @@ class AppTests(unittest.TestCase):
                 flush_transactions.parse(
                     args=[
                         "testscope0001",
+                        "-p",
                         "TestFlushPortfolio",
                         "-s",
                         "2017-02-10T00:00:00.0000000+00:00",
@@ -434,6 +437,7 @@ class AppTests(unittest.TestCase):
         args = flush_transactions.parse(
             args=[
                 "testscope0001",
+                "-p",
                 "support_non_existent_portfolio_tester",
                 "-s",
                 "2016-03-05T12:00:00+00:00",
@@ -457,6 +461,7 @@ class AppTests(unittest.TestCase):
         args = flush_transactions.parse(
             args=[
                 "testscope0001",
+                "-p",
                 "FlushFailedResponseTestPortfolio",
                 "-s",
                 "2017-02-10T00:00:00.0000000+00:00",
@@ -520,7 +525,7 @@ class AppTests(unittest.TestCase):
     def test_flush_with_portfolio_groups(
         self, _, group_scope, group_name, target_success
     ):
-        args = flush_transactions.parse(args=[group_scope, group_name, "--group"])
+        args = flush_transactions.parse(args=[group_scope, "-p", group_name, "--group"])
         args.secrets = self.secrets
 
         success_count, failure_count = flush_transactions.flush(args)

--- a/tests/integration/apps/test_command_line_apps.py
+++ b/tests/integration/apps/test_command_line_apps.py
@@ -409,6 +409,48 @@ class AppTests(unittest.TestCase):
                 ),
                 0,
             ],
+            [
+                "outside_the_test_data_time_for_scope",
+                flush_transactions.parse(
+                    args=[
+                        "testscope0001",
+                        "-s",
+                        "2020-02-20T00:00:00.0000000+00:00",
+                        "-e",
+                        "2020-02-28T23:59:59.0000000+00:00",
+                        "--flush_scope"
+                    ]
+                ),
+                6,
+            ],
+            [
+                "partly_inside_the_test_data_time_for_scope",
+                flush_transactions.parse(
+                    args=[
+                        "testscope0001",
+                        "-s",
+                        "2020-02-18T00:00:00.0000000+00:00",
+                        "-e",
+                        "2020-02-28T23:59:59.0000000+00:00",
+                        "--flush_scope"
+                    ]
+                ),
+                4,
+            ],
+            [
+                "inside_the_test_data_time_for_scope",
+                flush_transactions.parse(
+                    args=[
+                        "testscope0001",
+                        "-s",
+                        "2017-02-10T00:00:00.0000000+00:00",
+                        "-e",
+                        "2020-02-28T23:59:59.0000000+00:00",
+                        "--flush_scope"
+                    ]
+                ),
+                0,
+            ],
         ]
     )
     def test_flush_between_dates(self, _, args, expected_txn_count):
@@ -429,7 +471,9 @@ class AppTests(unittest.TestCase):
         flush_transactions.flush(args)
         args.end_date = None
         args.start_date = None
-        observed_count = len(list(flush_transactions.get_all_txns(args).values())[0])
+        observed_count = 0
+        for txn_list in list(flush_transactions.get_all_txns(args).values()):
+            observed_count += len(txn_list)
 
         self.assertEqual(expected_txn_count, observed_count)
 

--- a/tests/unit/apps/test_command_line_utilities.py
+++ b/tests/unit/apps/test_command_line_utilities.py
@@ -321,6 +321,7 @@ class AppTests(unittest.TestCase):
                 flush.parse(
                     args=[
                         "test-scope",
+                        "-p",
                         "FAndFTestPortfolio01",
                         "-s",
                         "2020-02-10T00:00:00.0000000+00:00",
@@ -335,6 +336,7 @@ class AppTests(unittest.TestCase):
                 flush.parse(
                     args=[
                         "test-scope",
+                        "-p",
                         "FAndFTestPortfolio01",
                         "-s",
                         "2020-02-10T00:00:00.0000000+00:00",


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [X] Tests pass

# Description of the PR

Changing the flush_transactions LPT app so that it can take a scope and flush all transactions for portfolios in the scope. 

This is a breaking change as the portfolio argument was previously required and is now optional and must be proceeded with a `-p` flag. 

To add some level of protection when flushing, an additional flag `--flush_scope` must be passed if all portfolios in the scope are to be flushed.
