### PR TITLE
CTECH-227: Added to format_transactions to print the number of transactions

### DIFF
--- a/lusidtools/cocoon/cocoon_printer.py
+++ b/lusidtools/cocoon/cocoon_printer.py
@@ -238,6 +238,10 @@ def format_transactions_response(
          successful calls from request
     error : pd.DataFrame
         Error responses from request that fail (APIExceptions: 400 errors)
+
+    Prints
+    -----------
+    Number of transactions
     """
 
     file_type = "transactions"
@@ -253,9 +257,15 @@ def format_transactions_response(
         response[file_type]["errors"], extended_error_details
     )
 
+    number_of_transactions = len(response[file_type]["success"])
+    portfolios = get_portfolio_from_href(items_success, file_type)
+    number_of_portfolios = len(set(portfolios))
+
+    print(f"{number_of_transactions} transactions upserted across {number_of_portfolios} portfolios")
+
     return (
         pd.DataFrame(
-            get_portfolio_from_href(items_success, file_type),
+            portfolios,
             columns=["successful items"],
         ),
         errors,


### PR DESCRIPTION
transactions

# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR
I counted the number of successful responses and the number of unique portfolios it acts on from the responses variable. Then I printed this information out into the console. 
Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
