### PR TITLE
feature/CTECH-177: load_from_data_frame now creates sub_holding_keys for

### DIFF
--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -1689,15 +1689,16 @@ def load_from_data_frame(
             property_columns=[{"source": key} for key in sub_holding_keys_codes],
         )
 
+        transaction_portfolio_api = api_factory.build(lusid.api.TransactionPortfoliosApi)
+
         # Add subholding keys to the portfolios we are going to apply the transactions to
         for code in set(data_frame[mapping_required['code']]):
-            api_factory.build(
-                lusid.api.TransactionPortfoliosApi
-            ).patch_portfolio_details(scope, code, [{"value": cocoon.properties._infer_full_property_keys(
-                partial_keys=sub_holding_keys,
-                properties_scope=properties_scope,
-                domain="Transaction",
-            ), "path": "/subHoldingKeys", "op": "add"}])
+            transaction_portfolio_api.patch_portfolio_details(scope, code,
+                                                              [{"value": cocoon.properties._infer_full_property_keys(
+                                                                  partial_keys=sub_holding_keys,
+                                                                  properties_scope=properties_scope,
+                                                                  domain="Transaction",
+                                                              ), "path": "/subHoldingKeys", "op": "add"}])
 
         # Add sub-holding keys to the properties, so it is created for each transaction.
         property_columns += [{'source': sub_holding_key, 'target': sub_holding_key} for sub_holding_key in

--- a/lusidtools/cocoon/cocoon.py
+++ b/lusidtools/cocoon/cocoon.py
@@ -33,7 +33,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_instrument_batch(
-        api_factory: lusid.utilities.ApiClientFactory, instrument_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, instrument_batch: list, **kwargs
     ) -> lusid.models.UpsertInstrumentsResponse:
         """
         Upserts a batch of instruments to LUSID
@@ -63,7 +63,7 @@ class BatchLoader:
 
         @checkargs
         def get_alphabetically_first_identifier_key(
-            instrument: lusid.models.InstrumentDefinition, unique_identifiers: list
+                instrument: lusid.models.InstrumentDefinition, unique_identifiers: list
         ):
             """
             Gets the alphabetically first occurring unique identifier on an instrument and use it as the correlation
@@ -105,7 +105,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_quote_batch(
-        api_factory: lusid.utilities.ApiClientFactory, quote_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, quote_batch: list, **kwargs
     ) -> lusid.models.UpsertQuotesResponse:
         """
         Upserts a batch of quotes into LUSID
@@ -148,7 +148,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_transaction_batch(
-        api_factory: lusid.utilities.ApiClientFactory, transaction_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, transaction_batch: list, **kwargs
     ) -> lusid.models.UpsertPortfolioTransactionsResponse:
         """
         Upserts a batch of transactions into LUSID
@@ -191,7 +191,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_holding_batch(
-        api_factory: lusid.utilities.ApiClientFactory, holding_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, holding_batch: list, **kwargs
     ) -> lusid.models.HoldingsAdjustment:
         """
         Upserts a batch of holdings into LUSID
@@ -234,8 +234,8 @@ class BatchLoader:
 
         # If only an adjustment has been specified
         if (
-            "holdings_adjustment_only" in list(kwargs.keys())
-            and kwargs["holdings_adjustment_only"]
+                "holdings_adjustment_only" in list(kwargs.keys())
+                and kwargs["holdings_adjustment_only"]
         ):
             return api_factory.build(
                 lusid.api.TransactionPortfoliosApi
@@ -256,7 +256,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_portfolio_batch(
-        api_factory: lusid.utilities.ApiClientFactory, portfolio_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, portfolio_batch: list, **kwargs
     ) -> lusid.models.Portfolio:
         """
         Upserts a batch of portfolios to LUSID
@@ -308,9 +308,9 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_reference_portfolio_batch(
-        api_factory: lusid.utilities.ApiClientFactory,
-        reference_portfolio_batch: list,
-        **kwargs,
+            api_factory: lusid.utilities.ApiClientFactory,
+            reference_portfolio_batch: list,
+            **kwargs,
     ) -> lusid.models.Portfolio:
         """
         Upserts a batch of reference portfolios to LUSID
@@ -363,7 +363,7 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_instrument_property_batch(
-        api_factory: lusid.utilities.ApiClientFactory, property_batch: list, **kwargs
+            api_factory: lusid.utilities.ApiClientFactory, property_batch: list, **kwargs
     ) -> [lusid.models.UpsertInstrumentPropertiesResponse]:
         """
         Add properties to the set instruments
@@ -436,9 +436,9 @@ class BatchLoader:
     @staticmethod
     @run_in_executor
     def load_portfolio_group_batch(
-        api_factory: lusid.utilities.ApiClientFactory,
-        portfolio_group_batch: list,
-        **kwargs,
+            api_factory: lusid.utilities.ApiClientFactory,
+            portfolio_group_batch: list,
+            **kwargs,
     ) -> lusid.models.PortfolioGroup:
         """
         Upserts a batch of portfolios to LUSID
@@ -485,7 +485,7 @@ class BatchLoader:
 
             #  Capture all portfolios - the ones currently in group + the new ones to be added
             all_portfolios_to_add = (
-                updated_request.values + current_portfolio_group.portfolios
+                    updated_request.values + current_portfolio_group.portfolios
             )
 
             current_portfolios_in_group = [
@@ -508,7 +508,7 @@ class BatchLoader:
             ]
 
             for code, scope in set(
-                [(resource.code, resource.scope) for resource in new_portfolios]
+                    [(resource.code, resource.scope) for resource in new_portfolios]
             ):
 
                 try:
@@ -541,10 +541,10 @@ class BatchLoader:
 
 
 async def _load_data(
-    api_factory: lusid.utilities.ApiClientFactory,
-    single_requests: list,
-    file_type: str,
-    **kwargs,
+        api_factory: lusid.utilities.ApiClientFactory,
+        single_requests: list,
+        file_type: str,
+        **kwargs,
 ):
     """
     This function calls the appropriate batch loader
@@ -583,17 +583,17 @@ async def _load_data(
 
 
 def _convert_batch_to_models(
-    data_frame: pd.DataFrame,
-    mapping_required: dict,
-    mapping_optional: dict,
-    property_columns: list,
-    properties_scope: str,
-    instrument_identifier_mapping: dict,
-    file_type: str,
-    domain_lookup: dict,
-    sub_holding_keys: list,
-    sub_holding_keys_scope: str,
-    **kwargs,
+        data_frame: pd.DataFrame,
+        mapping_required: dict,
+        mapping_optional: dict,
+        property_columns: list,
+        properties_scope: str,
+        instrument_identifier_mapping: dict,
+        file_type: str,
+        domain_lookup: dict,
+        sub_holding_keys: list,
+        sub_holding_keys_scope: str,
+        **kwargs,
 ):
     """
     This function populates the required models from a DataFrame and loads the data into LUSID
@@ -644,8 +644,8 @@ def _convert_batch_to_models(
     # If there is a sub_holding_keys attribute and it has a dict type this means the sub_holding_keys
     # need to be populated with property values
     if (
-        "sub_holding_keys" in open_api_types.keys()
-        and "dict" in open_api_types["sub_holding_keys"]
+            "sub_holding_keys" in open_api_types.keys()
+            and "dict" in open_api_types["sub_holding_keys"]
     ):
         sub_holding_key_dtypes = data_frame.loc[:, sub_holding_keys].dtypes
     # If not and they are provided as full keys
@@ -686,8 +686,8 @@ def _convert_batch_to_models(
 
         # Create the sub-holding-keys for this row
         if (
-            "sub_holding_keys" in open_api_types.keys()
-            and "dict" in open_api_types["sub_holding_keys"]
+                "sub_holding_keys" in open_api_types.keys()
+                and "dict" in open_api_types["sub_holding_keys"]
         ):
             sub_holding_keys_row = cocoon.properties.create_property_values(
                 row=row,
@@ -699,7 +699,7 @@ def _convert_batch_to_models(
 
         # Create identifiers for this row if applicable
         if instrument_identifier_mapping is None or not bool(
-            instrument_identifier_mapping
+                instrument_identifier_mapping
         ):
             identifiers = None
         else:
@@ -729,20 +729,20 @@ def _convert_batch_to_models(
 
 
 async def _construct_batches(
-    api_factory: lusid.utilities.ApiClientFactory,
-    data_frame: pd.DataFrame,
-    mapping_required: dict,
-    mapping_optional: dict,
-    property_columns: list,
-    properties_scope: str,
-    instrument_identifier_mapping: dict,
-    batch_size: int,
-    file_type: str,
-    domain_lookup: dict,
-    sub_holding_keys: list,
-    sub_holding_keys_scope: str,
-    return_unmatched_items: bool,
-    **kwargs,
+        api_factory: lusid.utilities.ApiClientFactory,
+        data_frame: pd.DataFrame,
+        mapping_required: dict,
+        mapping_optional: dict,
+        property_columns: list,
+        properties_scope: str,
+        instrument_identifier_mapping: dict,
+        batch_size: int,
+        file_type: str,
+        domain_lookup: dict,
+        sub_holding_keys: list,
+        sub_holding_keys_scope: str,
+        return_unmatched_items: bool,
+        **kwargs,
 ):
     """
     This constructs the batches and asynchronously sends them to be loaded into LUSID
@@ -826,7 +826,7 @@ async def _construct_batches(
             effective_at_groups = [
                 data_frame.loc[
                     data_frame[mapping_required["effective_at"]] == effective_at
-                ]
+                    ]
                 for effective_at in unique_effective_dates
             ]
 
@@ -837,7 +837,7 @@ async def _construct_batches(
                     "async_batches": [
                         effective_at_group.loc[
                             data_frame[mapping_required["code"]] == code
-                        ]
+                            ]
                         for code in list(
                             effective_at_group[mapping_required["code"]].unique()
                         )
@@ -846,13 +846,13 @@ async def _construct_batches(
                         effective_at_group[mapping_required["code"]].unique()
                     ),
                     "effective_at": [
-                        list(
-                            effective_at_group[
-                                mapping_required["effective_at"]
-                            ].unique()
-                        )[0]
-                    ]
-                    * len(list(effective_at_group[mapping_required["code"]].unique())),
+                                        list(
+                                            effective_at_group[
+                                                mapping_required["effective_at"]
+                                            ].unique()
+                                        )[0]
+                                    ]
+                                    * len(list(effective_at_group[mapping_required["code"]].unique())),
                 }
                 for effective_at_group in effective_at_groups
             ]
@@ -933,7 +933,7 @@ async def _construct_batches(
     # Raise any internal exceptions rather than propagating them to the response
     for response in responses_flattened:
         if isinstance(response, Exception) and not isinstance(
-            response, lusid.exceptions.ApiException
+                response, lusid.exceptions.ApiException
         ):
             raise response
 
@@ -944,7 +944,7 @@ async def _construct_batches(
     }
 
     # For successful transactions or holdings file types, optionally return unmatched identifiers with the responses
-    if check_for_unmatched_items(flag=return_unmatched_items, file_type=file_type,):
+    if check_for_unmatched_items(flag=return_unmatched_items, file_type=file_type, ):
         logging.debug("returning unmatched identifiers with the responses")
         returned_response["unmatched_items"] = unmatched_items(
             api_factory=api_factory,
@@ -985,13 +985,13 @@ def check_for_unmatched_items(flag, file_type):
 
 @checkargs
 def unmatched_items(
-    api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
-    data_frame: pd.DataFrame,
-    mapping_required: dict,
-    file_type: str,
-    returned_response: dict,
-    sync_batches: list = None,
+        api_factory: lusid.utilities.ApiClientFactory,
+        scope: str,
+        data_frame: pd.DataFrame,
+        mapping_required: dict,
+        file_type: str,
+        returned_response: dict,
+        sync_batches: list = None,
 ):
     """
     This method orchestrates the identification of holdings or transactions objects that were successfully uploaded
@@ -1041,11 +1041,11 @@ def unmatched_items(
 
 
 def _unmatched_transactions(
-    api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
-    data_frame: pd.DataFrame,
-    mapping_required: dict,
-    sync_batches: list = None,
+        api_factory: lusid.utilities.ApiClientFactory,
+        scope: str,
+        data_frame: pd.DataFrame,
+        mapping_required: dict,
+        sync_batches: list = None,
 ):
     """
     This method identifies which instruments were not resolved with a transaction upload using load_from_data_frame.
@@ -1074,10 +1074,9 @@ def _unmatched_transactions(
 
     # For each portfolio, request the unmatched transactions from LUSID and append to the instantiated list
     for portfolio_code in portfolio_codes:
-
         portfolio_transactions = data_frame.loc[
             data_frame[mapping_required["code"]] == portfolio_code
-        ]
+            ]
         from_transaction_date = min(
             portfolio_transactions[mapping_required["transaction_date"]].apply(
                 lambda x: str(DateOrCutLabel(x))
@@ -1108,11 +1107,11 @@ def _unmatched_transactions(
 
 
 def return_unmatched_transactions(
-    api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
-    code: str,
-    from_transaction_date: str,
-    to_transaction_date: str,
+        api_factory: lusid.utilities.ApiClientFactory,
+        scope: str,
+        code: str,
+        from_transaction_date: str,
+        to_transaction_date: str,
 ):
     """
     Call the get transactions api and only return those transactions with unresolved identifiers.
@@ -1163,7 +1162,7 @@ def return_unmatched_transactions(
 
 
 def filter_unmatched_transactions(
-    data_frame: pd.DataFrame, mapping_required: dict, unmatched_transactions: list,
+        data_frame: pd.DataFrame, mapping_required: dict, unmatched_transactions: list,
 ):
     """
     This method will take the full list of unmatched transactions and remove any transactions that were not
@@ -1196,9 +1195,9 @@ def filter_unmatched_transactions(
 
 
 def _unmatched_holdings(
-    api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
-    sync_batches: list = None,
+        api_factory: lusid.utilities.ApiClientFactory,
+        scope: str,
+        sync_batches: list = None,
 ):
     """
     This method identifies which instruments were not resolved with a holdings upload using load_from_data_frame.
@@ -1235,7 +1234,7 @@ def _unmatched_holdings(
 
 
 def return_unmatched_holdings(
-    api_factory: lusid.utilities.ApiClientFactory, scope: str, code_tuple: (str, str),
+        api_factory: lusid.utilities.ApiClientFactory, scope: str, code_tuple: (str, str),
 ):
     """
     Call the get holdings adjustments api and return a list of holding objects that have unresolved identifiers.
@@ -1283,24 +1282,24 @@ def return_unmatched_holdings(
 
 @checkargs
 def load_from_data_frame(
-    api_factory: lusid.utilities.ApiClientFactory,
-    scope: str,
-    data_frame: pd.DataFrame,
-    mapping_required: dict,
-    mapping_optional: dict,
-    file_type: str,
-    identifier_mapping: dict = None,
-    property_columns: list = None,
-    properties_scope: str = None,
-    batch_size: int = None,
-    remove_white_space: bool = True,
-    instrument_name_enrichment: bool = False,
-    sub_holding_keys: list = None,
-    holdings_adjustment_only: bool = False,
-    thread_pool_max_workers: int = 5,
-    sub_holding_keys_scope: str = None,
-    return_unmatched_items: bool = False,
-    instrument_scope: str = None,
+        api_factory: lusid.utilities.ApiClientFactory,
+        scope: str,
+        data_frame: pd.DataFrame,
+        mapping_required: dict,
+        mapping_optional: dict,
+        file_type: str,
+        identifier_mapping: dict = None,
+        property_columns: list = None,
+        properties_scope: str = None,
+        batch_size: int = None,
+        remove_white_space: bool = True,
+        instrument_name_enrichment: bool = False,
+        sub_holding_keys: list = None,
+        holdings_adjustment_only: bool = False,
+        thread_pool_max_workers: int = 5,
+        sub_holding_keys_scope: str = None,
+        return_unmatched_items: bool = False,
+        instrument_scope: str = None,
 ):
     """
 
@@ -1646,10 +1645,9 @@ def load_from_data_frame(
     # If there is a sub_holding_keys attribute and it has a dict type this means the sub_holding_keys
     # need to have a property definition and be populated with values from the provided dataframe columns
     if (
-        "sub_holding_keys" in open_api_types.keys()
-        and "dict" in open_api_types["sub_holding_keys"]
+            "sub_holding_keys" in open_api_types.keys()
+            and "dict" in open_api_types["sub_holding_keys"]
     ):
-
         Validator(sub_holding_keys, "sub_holding_key_columns").check_subset_of_list(
             data_frame_columns, "DataFrame Columns"
         )
@@ -1662,6 +1660,32 @@ def load_from_data_frame(
             data_frame=data_frame,
             property_columns=[{"source": key} for key in sub_holding_keys],
         )
+
+    # If the transaction contains subholding keys which aren't defined in the portfolio. We first create the
+    # properties that don't already exist, then we make the properties sub-holding keys in the portfolios.
+    if file_type == "transaction" and sub_holding_keys is not None and sub_holding_keys != []:
+        # Check for and create missing property definitions for the sub-holding-keys
+        data_frame = cocoon.properties.create_missing_property_definitions_from_file(
+            api_factory=api_factory,
+            properties_scope=properties_scope,
+            domain="Transaction",
+            data_frame=data_frame,
+            property_columns=[{"source": key} for key in sub_holding_keys],
+        )
+
+        # Add subholding keys to the portfolios we are going to apply the transactions to
+        for code in set(data_frame[mapping_required['code']]):
+            api_factory.build(
+                lusid.api.TransactionPortfoliosApi
+            ).patch_portfolio_details(scope, code, [{"value": cocoon.properties._infer_full_property_keys(
+                partial_keys=sub_holding_keys,
+                properties_scope=properties_scope,
+                domain="Transaction",
+            ), "path": "/subHoldingKeys", "op": "add"}])
+
+        # Add sub-holding keys to the properties, so it is created for each transaction.
+        property_columns += [{'source': sub_holding_key, 'target': sub_holding_key} for sub_holding_key in
+                             sub_holding_keys]
 
     # Check for and create missing property definitions for the properties
     if domain_lookup[file_type]["domain"] is not None:

--- a/tests/integration/cocoon/data/no-subholding-keys-transactions.csv
+++ b/tests/integration/cocoon/data/no-subholding-keys-transactions.csv
@@ -1,0 +1,3 @@
+﻿portfolio_code,id,transaction_type,transaction_date,settlement_date,units,transaction_price,amount,trade_currency,instrument_name,accounting_method,mtom,broker_executor,location_region,isin,figi,client_internal,exposure_counterparty,val,compls,source,price_type,currency_transaction,SHK_data
+no-SHK,ab1543673,FundsIn,2019-09-01T09:31:22.664000+00:00,2019-09-01T09:31:22.664000+00:00,1000000000,1,1000000000,USD,USD,13,0,xy35920,CR,NaN,NaN,NaN,NaN,nan,NaN,US_SimcorpDimension,Price,USD,0
+no-SHK,ab154367,FundsIn,2019-09-01T09:31:22.664000+00:00,2019-09-01T09:31:22.664000+00:00,3200000000,1,1000000000,USD,USD,13,0,xy35920,CR,NaN,NaN,NaN,NaN,nan,NaN,US_SimcorpDimension,Price,USD,1

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import unittest
 import uuid
@@ -871,10 +872,16 @@ class CocoonTestsTransactions(unittest.TestCase):
         """
         This checks whether load_from_data_frame creates subholding keys for transactions when they don't already exist.
         """
+        portfolios = self.api_factory.build(lusid.PortfoliosApi).list_portfolios_for_scope(scope).values
+
+        for portfolio in portfolios:
+            self.api_factory.build(lusid.PortfoliosApi).delete_portfolio(scope, portfolio.id.code)
+
+        self.api_factory.build(lusid.TransactionPortfoliosApi).create_portfolio(scope, {'displayName': "test_load_from_dataframe_non_existent_subholding_keys portfolio", 'code': 'no-SHK', 'baseCurrency': 'GBP', 'created': "2017-06-22T00:00:00.0000000+00:00"})
 
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
 
-        responses = cocoon.cocoon.load_from_data_frame(
+        cocoon.cocoon.load_from_data_frame(
             api_factory=self.api_factory,
             scope=scope,
             data_frame=data_frame,

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -922,13 +922,16 @@ class CocoonTestsTransactions(unittest.TestCase):
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[0].properties.keys())
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[1].properties.keys())
 
-        # delete the property now that we know that it exists.
-        self.api_factory.build(lusid.PropertyDefinitionsApi).delete_property_definition('Transaction',
+        # delete the property
+        try:
+            self.api_factory.build(lusid.PropertyDefinitionsApi).delete_property_definition('Transactions',
                                                                                         'load_dataframe_test',
                                                                                         'SHK_data')
+        except lusid.ApiException as e:
+            if 'domain' not in str(e.body) and 'PropertyNotDefined' not in str(e.body):
+                raise e
 
-
-        # check that the property is a sub-holding key in the portfolio.
+        # check that the property is a sub-holding key in the portfolio
         self.assertSetEqual(
             set(portfolio_details.sub_holding_keys), set(expected_sub_holdings_keys)
         )

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -12,7 +12,6 @@ import lusid
 from lusidtools import logger
 from lusidtools.cocoon.utilities import create_scope_id
 
-
 client_internal = "Instrument/default/ClientInternal"
 sedol = "Instrument/default/Sedol"
 name = "Instrument/default/Name"
@@ -270,17 +269,17 @@ class CocoonTestsTransactions(unittest.TestCase):
         ]
     )
     def test_load_from_data_frame_transactions_success(
-        self,
-        _,
-        scope,
-        file_name,
-        mapping_required,
-        mapping_optional,
-        identifier_mapping,
-        property_columns,
-        properties_scope,
-        batch_size,
-        expected_outcome,
+            self,
+            _,
+            scope,
+            file_name,
+            mapping_required,
+            mapping_optional,
+            identifier_mapping,
+            property_columns,
+            properties_scope,
+            batch_size,
+            expected_outcome,
     ) -> None:
         """
         Test that transactions
@@ -397,16 +396,16 @@ class CocoonTestsTransactions(unittest.TestCase):
         ]
     )
     def test_properties_dicts(
-        self,
-        _,
-        scope,
-        mapping_required,
-        mapping_optional,
-        identifier_mapping,
-        property_columns,
-        properties_scope,
-        expected_property_scope,
-        expected_property_code,
+            self,
+            _,
+            scope,
+            mapping_required,
+            mapping_optional,
+            identifier_mapping,
+            property_columns,
+            properties_scope,
+            expected_property_scope,
+            expected_property_code,
     ) -> None:
         """
         Test that transactions
@@ -494,12 +493,12 @@ class CocoonTestsTransactions(unittest.TestCase):
                 "Test standard transaction load with two unresolved instruments",
                 "data/global-fund-combined-transactions-unresolved-instruments.csv",
                 True,
-                ["unresolved_tx01", "unresolved_tx02",],
+                ["unresolved_tx01", "unresolved_tx02", ],
             ],
         ]
     )
     def test_load_from_data_frame_transactions_success_with_correct_unmatched_identifiers(
-        self, _, file_name, return_unmatched_items, expected_unmatched_transactions,
+            self, _, file_name, return_unmatched_items, expected_unmatched_transactions,
     ) -> None:
         """
         Test that transactions are uploaded and have the expected response from load_from_data_frame
@@ -580,7 +579,7 @@ class CocoonTestsTransactions(unittest.TestCase):
 
     @lusid_feature("T8-10")
     def test_return_unmatched_transactions_extracts_relevant_transactions_and_instruments(
-        self,
+            self,
     ):
         scope = "unmatched_transactions_test"
         code = "MIS_INST_FUND"
@@ -704,11 +703,11 @@ class CocoonTestsTransactions(unittest.TestCase):
         ]
     )
     def test_filter_unmatched_transactions_method_only_returns_transactions_originally_present_in_dataframe(
-        self,
-        _,
-        data_frame_path,
-        unmatched_transactions,
-        expected_filtered_unmatched_transactions,
+            self,
+            _,
+            data_frame_path,
+            unmatched_transactions,
+            expected_filtered_unmatched_transactions,
     ):
         """
         Test that unmatched transactions that were not part of the current load_from_data_frame operation are
@@ -739,7 +738,7 @@ class CocoonTestsTransactions(unittest.TestCase):
 
     @lusid_feature("T8-14")
     def test_filter_unmatched_transactions_can_paginate_responses_for_2001_transactions_returned(
-        self,
+            self,
     ):
         """
         The GetTransactions API will only return up to 2,000 transactions per request. This test is to verify that
@@ -856,28 +855,32 @@ class CocoonTestsTransactions(unittest.TestCase):
         ]
     )
     def test_load_from_dataframe_non_existent_subholding_keys(
-        self,
-        _,
-        scope,
-        file_name,
-        mapping_required,
-        mapping_optional,
-        identifier_mapping,
-        property_columns,
-        properties_scope,
-        batch_size,
-        sub_holding_keys,
-        expected_sub_holdings_keys
+            self,
+            _,
+            scope,
+            file_name,
+            mapping_required,
+            mapping_optional,
+            identifier_mapping,
+            property_columns,
+            properties_scope,
+            batch_size,
+            sub_holding_keys,
+            expected_sub_holdings_keys
     ):
         """
         This checks whether load_from_data_frame creates subholding keys for transactions when they don't already exist.
         """
-        portfolios = self.api_factory.build(lusid.PortfoliosApi).list_portfolios_for_scope(scope).values
+        portfolios_api = self.api_factory.build(lusid.PortfoliosApi)
+        transaction_portfolio_api = self.api_factory.build(lusid.TransactionPortfoliosApi)
+        portfolios = portfolios_api.list_portfolios_for_scope(scope).values
 
         for portfolio in portfolios:
-            self.api_factory.build(lusid.PortfoliosApi).delete_portfolio(scope, portfolio.id.code)
+            portfolios_api.delete_portfolio(scope, portfolio.id.code)
 
-        self.api_factory.build(lusid.TransactionPortfoliosApi).create_portfolio(scope, {'displayName': "test_load_from_dataframe_non_existent_subholding_keys portfolio", 'code': 'no-SHK', 'baseCurrency': 'GBP', 'created': "2017-06-22T00:00:00.0000000+00:00"})
+        transaction_portfolio_api.create_portfolio(scope, {
+            'displayName': "test_load_from_dataframe_non_existent_subholding_keys portfolio", 'code': 'no-SHK',
+            'baseCurrency': 'GBP', 'created': "2017-06-22T00:00:00.0000000+00:00"})
 
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
 
@@ -892,16 +895,18 @@ class CocoonTestsTransactions(unittest.TestCase):
             property_columns=property_columns,
             properties_scope=properties_scope,
             batch_size=batch_size,
-            sub_holding_keys = sub_holding_keys
+            sub_holding_keys=sub_holding_keys
         )
 
-        portfolio_details = self.api_factory.build(
-            lusid.api.TransactionPortfoliosApi
-        ).get_details(scope=scope, code='no-SHK')
+        portfolio_details = transaction_portfolio_api.get_details(scope=scope, code='no-SHK')
 
-        transactions = self.api_factory.build(
-            lusid.api.TransactionPortfoliosApi
-        ).get_transactions(scope = scope, code = 'no-SHK')
+        transactions = transaction_portfolio_api.get_transactions(scope=scope, code='no-SHK')
+
+        try:
+            portfolios_api.delete_portfolio(scope, 'no-SHK')
+        except lusid.ApiException as e:
+            if "PortfolioNotFound" not in str(e.body):
+                raise e
 
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[0].properties.keys())
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[1].properties.keys())

--- a/tests/integration/cocoon/test_cocoon_transactions.py
+++ b/tests/integration/cocoon/test_cocoon_transactions.py
@@ -871,19 +871,26 @@ class CocoonTestsTransactions(unittest.TestCase):
         """
         This checks whether load_from_data_frame creates subholding keys for transactions when they don't already exist.
         """
+
+        # create the apis to reduce repeat definitions
         portfolios_api = self.api_factory.build(lusid.PortfoliosApi)
         transaction_portfolio_api = self.api_factory.build(lusid.TransactionPortfoliosApi)
+
+        # make sure the portfolio doesn't already exist in scope
         portfolios = portfolios_api.list_portfolios_for_scope(scope).values
 
         for portfolio in portfolios:
             portfolios_api.delete_portfolio(scope, portfolio.id.code)
 
+        # create the portfolio we're going to use
         transaction_portfolio_api.create_portfolio(scope, {
             'displayName': "test_load_from_dataframe_non_existent_subholding_keys portfolio", 'code': 'no-SHK',
             'baseCurrency': 'GBP', 'created': "2017-06-22T00:00:00.0000000+00:00"})
 
+        # load the data
         data_frame = pd.read_csv(Path(__file__).parent.joinpath(file_name))
 
+        # load in the transactions along with the sub-holding keys
         cocoon.cocoon.load_from_data_frame(
             api_factory=self.api_factory,
             scope=scope,
@@ -898,19 +905,30 @@ class CocoonTestsTransactions(unittest.TestCase):
             sub_holding_keys=sub_holding_keys
         )
 
+        # we get the details from the portfolio
         portfolio_details = transaction_portfolio_api.get_details(scope=scope, code='no-SHK')
 
+        # get the transactions that we just loaded in
         transactions = transaction_portfolio_api.get_transactions(scope=scope, code='no-SHK')
 
+        # delete the portfolio as it is no longer required
         try:
             portfolios_api.delete_portfolio(scope, 'no-SHK')
         except lusid.ApiException as e:
             if "PortfolioNotFound" not in str(e.body):
                 raise e
 
+        # check that the sub holding key is a property of the two transactions
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[0].properties.keys())
         self.assertTrue('Transaction/load_dataframe_test/SHK_data' in transactions.values[1].properties.keys())
 
+        # delete the property now that we know that it exists.
+        self.api_factory.build(lusid.PropertyDefinitionsApi).delete_property_definition('Transaction',
+                                                                                        'load_dataframe_test',
+                                                                                        'SHK_data')
+
+
+        # check that the property is a sub-holding key in the portfolio.
         self.assertSetEqual(
             set(portfolio_details.sub_holding_keys), set(expected_sub_holdings_keys)
         )


### PR DESCRIPTION
transactions when they don't exist on the portfolio.

just added some lines to the function that checks when the sub_holding_key variable is not empty (for transactions) and creates a property for it, if it doesn't exist. Then adds the properties as subholding keys to the parent portfolios of the transactions.

I also added a test which checks whether the sub_holding_key exists on the portfolio after running the function with transaction data and tests that the properties were added to the transactions.
