### PR TITLE
feature/CTECH-308: resolved SettingWithCopyWarning.

### DIFF
--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -837,8 +837,9 @@ def handle_nested_default_and_column_mapping(
         The updated mapping
     """
 
-    # copy the data frame to ensure that it is a copy and not a view (which could make changes to the original
-    # dataframe).
+    # Copy the data frame to ensure that it is a copy and not a view (which could make changes to the original
+    # dataframe). This also fixes the SettingWithCopyWarning that pandas will throw due to the difference between copy
+    # and view.
     data_frame = data_frame.copy()
 
     mapping_updated = {}

--- a/lusidtools/cocoon/utilities.py
+++ b/lusidtools/cocoon/utilities.py
@@ -837,6 +837,10 @@ def handle_nested_default_and_column_mapping(
         The updated mapping
     """
 
+    # copy the data frame to ensure that it is a copy and not a view (which could make changes to the original
+    # dataframe).
+    data_frame = data_frame.copy()
+
     mapping_updated = {}
 
     for key, value in mapping.items():


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

This is a one line fix. I believe the issue is due to whether a data frame is a copy or a view. If the data frame is a view then it acts like a reference to the original data frame, so any changes will affect both data frames. This becomes an issue when we pass in the data_frame.loc[...], since loc can either return a copy of a data frame or a view of it depending on the memory. When we make assignments to columns of the data frame pandas warns us since it thinks we want to assign to a view when the data frame is actually a copy.

To ensure that the data frame is a copy, we just assign it to be the copy of itself at the start of the function. 
