### PR TITLE
CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ pytz>=2019.3
 boto3>=1.16.22
 IPython>=7.31.1
 
-lusid-sdk-preview>=0.11.4425, <= 1.0
+lusid-sdk-preview>=0.11.4425, < 2
 lusidfeature

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "boto3>=1.16.22",
         "IPython>=7.31.1",
 
-        "lusid-sdk-preview>=0.11.4425, <= 1.0"
+        "lusid-sdk-preview>=0.11.4425, < 2"
     ],
     include_package_data=True,
     python_requires=">=3.7",


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions 1.0.x however that is not true, so now pinning < 2
