### PR TITLE
SE-2734: Fixed iteritems to items

### DIFF
--- a/lusidtools/cocoon/properties.py
+++ b/lusidtools/cocoon/properties.py
@@ -347,7 +347,7 @@ def create_property_values(
     properties = {}
 
     # Iterate over each column name and data type
-    for column_name, data_type in dtypes.iteritems():
+    for column_name, data_type in dtypes.items():
 
         # Set the data type to be a string so that it is easier to work with
         string_data_type = str(data_type)


### PR DESCRIPTION
# Pull Request Checklist

Moves cocoon properties from using deprecated iteritems to items.

- [ x ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ x ] Tests pass

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
