### PR TITLE
CTECH-2361: Add a helper method that creates a role calling both the access and identity APIs

### DIFF
--- a/lusidtools/iam/__init__.py
+++ b/lusidtools/iam/__init__.py
@@ -1,0 +1,1 @@
+import lusidtools.iam.roles

--- a/lusidtools/iam/roles.py
+++ b/lusidtools/iam/roles.py
@@ -1,0 +1,88 @@
+import json
+
+import lusid
+import finbourne_access
+import finbourne_access.utilities
+import finbourne_identity
+
+from finbourne_access import models as access_models
+from finbourne_identity import models as identity_models
+
+from lusidtools.cocoon.utilities import (
+    checkargs,
+)
+import logging
+
+
+@checkargs
+def create_role(
+        api_factory: lusid.utilities.ApiClientFactory,
+        access_role_creation_request: access_models.RoleCreationRequest,
+):
+    """
+
+    Parameters
+    ----------
+    api_factory : lusid.utilities.ApiClientFactory api_factory
+        The api factory to use
+    access_role_creation_request : access_models.RoleCreationRequest
+        The role creation request to use
+
+    Returns
+    -------
+    responses: none
+
+    """
+
+    api_client = api_factory.api_client
+    lusid_api_url = api_client.configuration.host
+    access_token = api_client.configuration.access_token
+
+    # Build the access and identity API URLs from the LUSID API URL.
+    access_api_url = lusid_api_url[: lusid_api_url.rfind("/") + 1] + "access"
+    identity_api_url = lusid_api_url[: lusid_api_url.rfind("/") + 1] + "identity"
+
+    # Build the access and identity API factories.
+    access_api_factory = finbourne_access.utilities.ApiClientFactory(
+        token=access_token,
+        access_url=access_api_url,
+    )
+    identity_api_factory = finbourne_identity.utilities.ApiClientFactory(
+        token=access_token,
+        api_url=identity_api_url,
+    )
+
+    # Build the access and identity roles APIs.
+    access_roles_api = access_api_factory.build(finbourne_access.RolesApi)
+    identity_roles_api = identity_api_factory.build(finbourne_identity.RolesApi)
+
+    access_role_creation_success = False
+    identity_role_creation_success = False
+
+    # Create the role using the access API.
+    try:
+        access_roles_api.create_role(access_role_creation_request)
+        access_role_creation_success = True
+    except finbourne_access.ApiException as e:
+        detail = json.loads(e.body)
+        if detail['code'] not in [612, 613, 615]:  # RoleWithCodeAlreadyExists
+            raise e
+        logging.info(
+            f"Role with code {access_role_creation_request.code} has already been created via the access API"
+        )
+
+    # Create the same role using the identity API.
+    identity_role_creation_request = identity_models.CreateRoleRequest(access_role_creation_request.code)
+    try:
+        identity_roles_api.create_role(identity_role_creation_request)
+        identity_role_creation_success = True
+    except finbourne_identity.ApiException as e:
+        detail = json.loads(e.body)
+        if detail["code"] != 157:  # RoleWithCodeAlreadyExists
+            raise e
+        logging.info(
+            f"Role with code {access_role_creation_request.code} has already been created via the identity API"
+        )
+
+    if access_role_creation_success & identity_role_creation_success:
+        logging.info(f"Successfully created the role with code {access_role_creation_request.code}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ IPython>=7.31.1
 
 lusid-sdk-preview>=0.11.4425, < 2
 lusidfeature
+
+finbourne-access-sdk
+finbourne-identity-sdk

--- a/tests/integration/iam/test_iam_roles.py
+++ b/tests/integration/iam/test_iam_roles.py
@@ -1,0 +1,94 @@
+import os
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+import pytz
+
+import lusid
+import finbourne_access
+import finbourne_identity
+from finbourne_access.utilities import ApiClientFactory as AccessApiClientFactory
+from finbourne_access import models as access_models
+
+from lusidtools import iam as iam
+from lusidtools import logger
+
+
+class IAMTestsRoles(unittest.TestCase):
+    api_factory = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        secrets_file = Path(__file__).parent.parent.parent.joinpath("secrets.json")
+        print(secrets_file)
+        cls.api_factory = lusid.utilities.ApiClientFactory(
+            api_secrets_filename=secrets_file
+        )
+        cls.logger = logger.LusidLogger(os.getenv("FBN_LOG_LEVEL", "info"))
+
+    def test_create_role_success(
+        self
+    ) -> None:
+        """
+        Test that a role can be created successfully
+
+        :return: None
+        """
+
+        role_code = "TestRoleCode"
+        access_role_creation_request = access_models.RoleCreationRequest(
+            code=role_code,
+            description="Test Role Description",
+            resource=access_models.RoleResourceRequest(
+                policy_id_role_resource=access_models.PolicyIdRoleResource(
+                    policies=[
+                        access_models.PolicyId(scope="default", code="TestPolicyCode")
+                    ]
+                )
+            ),
+            when=access_models.WhenSpec(
+                activate=datetime.now(tz=pytz.utc) - timedelta(days=2),
+                deactivate=datetime(9999, 12, 31, tzinfo=pytz.utc)
+            )
+        )
+
+        # Create a role using the LPT create_role method
+        iam.roles.create_role(
+            self.api_factory,
+            access_role_creation_request
+        )
+
+        # Get the LUSID API URL and the access token from the current api_factory
+        api_client = self.api_factory.api_client
+        lusid_api_url = api_client.configuration.host
+        access_token = api_client.configuration.access_token
+
+        # Build the access and identity API URLs from the LUSID API URL.
+        access_api_url = lusid_api_url[: lusid_api_url.rfind("/") + 1] + "access"
+        identity_api_url = lusid_api_url[: lusid_api_url.rfind("/") + 1] + "identity"
+
+        # Build the access and identity API factories.
+        access_api_factory = finbourne_access.utilities.ApiClientFactory(
+            token=access_token,
+            access_url=access_api_url
+        )
+        identity_api_factory = finbourne_identity.utilities.ApiClientFactory(
+            token=api_client.configuration.access_token,
+            api_url=identity_api_url,
+        )
+
+        access_roles_api = access_api_factory.build(finbourne_access.RolesApi)
+        identity_roles_api = identity_api_factory.build(finbourne_identity.RolesApi)
+
+        access_role = access_roles_api.get_role(role_code)
+        self.assertEqual(
+            first=access_role.id.code,
+            second=role_code
+        )
+
+        identity_roles = identity_roles_api.list_roles()
+        identity_roles_codes = [role.role_id.code for role in identity_roles]
+        self.assertIn(
+            member=role_code,
+            container=identity_roles_codes
+        )


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](https://github.com/finbourne/lusid-python-tools/blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

Currently when creating a role in a python notebook you need to create a role via both the access API and identity API. This has to be done so that the access system (which handles applying policies to a role) can communicate with the identity system (which handles assigned roles to users).